### PR TITLE
ci: disable fail-fast in the test matrix

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,7 +8,12 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: true
+      # Run every Python version to completion even if one fails. The test job
+      # occasionally hits a flaky native SIGILL during import on a mismatched
+      # runner CPU/wheel; with fail-fast that one crash cancels the other
+      # versions and hides their real status. Keeping it false isolates the
+      # flake so you can re-run just the failed job (`gh run rerun --failed`).
+      fail-fast: false
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
 


### PR DESCRIPTION
## Problem

`run_tests.yml` runs a 3-job matrix (Python 3.11/3.12/3.13) with `fail-fast: true`. The test job intermittently hits a **flaky native SIGILL** during library import — a prebuilt `jaxlib`/`scipy`/`onnxruntime` wheel using a CPU instruction unsupported on some GitHub runner CPUs. It strikes a fraction of runs depending on which physical runner the job lands on, and crashes *before* pytest prints anything (exit code 132, zero output).

With `fail-fast: true`, that single flaky crash on one Python version **cancels the other two in-progress jobs**, so:
- the whole run goes red even though 3.11/3.12 were green,
- you lose the real pass/fail status of the other versions,
- the only recourse is a full-matrix re-run (3× cost).

This was reproduced as a control experiment: re-running a *known-green* commit with no code change produced the same `(3.13)=failure (3.11)=cancelled (3.12)=cancelled` pattern.

## Fix

Set `fail-fast: false`. Each Python version runs to completion independently, so a flaky SIGILL fails only its own job — 3.11/3.12 still report their true status, and you can re-run just the failed job (`gh run rerun --failed`, which lands on a fresh runner) instead of the whole matrix.

This isolates the flake and makes recovery cheap; it does **not** eliminate the SIGILL itself (the root cure would be pinning/constraining the offending native wheel — a separate, larger change that touches the lockfile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced test suite resilience by allowing Python version tests to run independently, preventing cascading failures when individual test runs encounter intermittent issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->