### PR TITLE
fix(onnx): bounded input slices in exporters (drop INT64_MAX slice sentinel)

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,7 +8,7 @@
     Navigate the site here!
 </span>
 <span class="right-margin">
-    <a href="https://github.com/lnccbrown/LANfactory/releases/latest">v0.7.0 is out!</a>
+    <a href="https://github.com/lnccbrown/LANfactory/releases/latest">v0.7.1 is out!</a>
 </span>
 <span>
     <span class="twemoji">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = ["setuptools", "wheel"]
 
 [project]
 name = "lanfactory"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     { name = "Alexander Fengler", email = "alexander_fengler@brown.edu" },
     { name = "Carlos Paniagua", email = "carlos_paniagua@brown.edu" },

--- a/src/lanfactory/__init__.py
+++ b/src/lanfactory/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 from . import config
 from . import trainers

--- a/src/lanfactory/onnx/bayesflow.py
+++ b/src/lanfactory/onnx/bayesflow.py
@@ -279,7 +279,7 @@ class _BayesflowNLELogProbWrapper(nn.Module):
     def forward(self, combined: torch.Tensor) -> torch.Tensor:
         # combined: rank-1, (theta_dim + x_dim,) — see module docstring.
         theta = combined[: self.theta_dim].unsqueeze(0)
-        x_obs = combined[self.theta_dim :].unsqueeze(0)
+        x_obs = combined[self.theta_dim : self.theta_dim + self.x_dim].unsqueeze(0)
 
         if self._x_mean is not None:
             x_obs = (x_obs - self._x_mean) / self._x_std
@@ -341,7 +341,7 @@ class _BayesflowNRELogRatioWrapper(nn.Module):
         # combined: rank-1, [theta..., x...]. Internal ordering matches the
         # bayesflow logits() convention: classifier_input = concat([θ, x]).
         theta = combined[: self.theta_dim].unsqueeze(0)
-        x_obs = combined[self.theta_dim :].unsqueeze(0)
+        x_obs = combined[self.theta_dim : self.theta_dim + self.x_dim].unsqueeze(0)
 
         if self._th_mean is not None:
             theta = (theta - self._th_mean) / self._th_std

--- a/src/lanfactory/onnx/sbi.py
+++ b/src/lanfactory/onnx/sbi.py
@@ -167,7 +167,7 @@ class _NLELogProbWrapper(nn.Module):
         # sbi's batched log_prob contract, and reshape the (1, 1) output back
         # to a scalar so HSSM's downstream .squeeze() leaves it as ().
         theta = combined[: self.theta_dim].unsqueeze(0)
-        x = combined[self.theta_dim :].unsqueeze(0)
+        x = combined[self.theta_dim : self.theta_dim + self.x_dim].unsqueeze(0)
         return self.estimator.log_prob(x, condition=theta).reshape(())
 
 
@@ -192,5 +192,5 @@ class _NRELogRatioWrapper(nn.Module):
         # combined: 1D, shape (theta_dim + x_dim,) — see _NLELogProbWrapper for
         # the rationale around rank-1 tracing and vmap compatibility.
         theta = combined[: self.theta_dim].unsqueeze(0)
-        x = combined[self.theta_dim :].unsqueeze(0)
+        x = combined[self.theta_dim : self.theta_dim + self.x_dim].unsqueeze(0)
         return self.estimator(theta, x).reshape(())

--- a/tests/test_bayesflow_nle_export.py
+++ b/tests/test_bayesflow_nle_export.py
@@ -310,6 +310,56 @@ def test_transform_rejects_invalid_mode(tmp_path: Path) -> None:
         )
 
 
+def _max_int64_abs(onnx_model: onnx.ModelProto) -> int:
+    """Largest absolute value stored in any int64 tensor in the graph (0 if none)."""
+    tensors = list(onnx_model.graph.initializer)
+    for node in onnx_model.graph.node:
+        for attr in node.attribute:
+            if attr.type == onnx.AttributeProto.TENSOR:
+                tensors.append(attr.t)
+            elif attr.type == onnx.AttributeProto.TENSORS:
+                tensors.extend(attr.tensors)
+    biggest = 0
+    for tensor in tensors:
+        if tensor.data_type == onnx.TensorProto.INT64:
+            arr = onnx.numpy_helper.to_array(tensor)
+            if arr.size:
+                biggest = max(biggest, int(np.abs(arr).max()))
+    return biggest
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="bayesflow's CouplingFlow emits internal INT64_MAX Constants (from its "
+    "open-ended split ops) that LANfactory cannot remove — so bayesflow ONNX is "
+    "NOT int32-clean even with bounded wrapper slices. Such exports require x64 on "
+    "the consumer side (or a value-aware int cast). This xfail is a tripwire: if "
+    "bayesflow ever stops emitting INT64_MAX, it will xpass and flag that the "
+    "consumer can drop its x64 requirement. Contrast test_sbi_nle_export, which "
+    "IS int32-clean after the bounded-slice fix.",
+)
+def test_export_int64_values_fit_in_int32(
+    trained_nle: bf.ContinuousApproximator, tmp_path: Path
+) -> None:
+    """Document: bayesflow exports are NOT int32-clean (flow-internal INT64_MAX).
+
+    The bounded-slice wrapper fix removes the wrapper-level ``INT64_MAX`` sentinel,
+    but bayesflow's CouplingFlow split ops emit their own — so this assertion fails
+    (xfail). The sbi exporter test of the same name passes because nflows/MAF does
+    not emit such sentinels.
+    """
+    onnx_path = tmp_path / "bayesflow_nle_int_range.onnx"
+    transform_bayesflow_to_onnx(
+        trained_nle,
+        str(onnx_path),
+        mode="nle",
+        example_theta_dim=_THETA_DIM,
+        example_x_dim=_X_DIM,
+    )
+    model = onnx.load(str(onnx_path))
+    assert _max_int64_abs(model) <= np.iinfo(np.int32).max
+
+
 def test_transform_rejects_nonpositive_dims(tmp_path: Path) -> None:
     """Zero or negative example dims raise a clear ValueError."""
 

--- a/tests/test_sbi_nle_export.py
+++ b/tests/test_sbi_nle_export.py
@@ -267,3 +267,44 @@ def test_transform_rejects_nonpositive_dims(tmp_path: Path) -> None:
             example_theta_dim=0,
             example_x_dim=2,
         )
+
+
+def _max_int64_abs(onnx_model: onnx.ModelProto) -> int:
+    """Largest absolute value stored in any int64 tensor in the graph (0 if none)."""
+    tensors = list(onnx_model.graph.initializer)
+    for node in onnx_model.graph.node:
+        for attr in node.attribute:
+            if attr.type == onnx.AttributeProto.TENSOR:
+                tensors.append(attr.t)
+            elif attr.type == onnx.AttributeProto.TENSORS:
+                tensors.extend(attr.tensors)
+    biggest = 0
+    for tensor in tensors:
+        if tensor.data_type == onnx.TensorProto.INT64:
+            arr = onnx.numpy_helper.to_array(tensor)
+            if arr.size:
+                biggest = max(biggest, int(np.abs(arr).max()))
+    return biggest
+
+
+def test_export_int64_values_fit_in_int32(
+    trained_nle: torch.nn.Module, tmp_path: Path
+) -> None:
+    """Regression: bounded input slices keep all int64 graph values within int32.
+
+    An open-ended ``combined[theta_dim:]`` slice bakes an ``INT64_MAX`` ``Slice``
+    'ends' sentinel into the graph; under ``jax_enable_x64=False`` that int64
+    truncates and ``INT64_MAX`` wraps to ``-1`` — silently turning "slice to end"
+    into "drop the last element". The NLE and NRE wrappers share the identical
+    bounded-slice code, so this guards both modes against a regression.
+    """
+    onnx_path = tmp_path / "sbi_nle_int_range.onnx"
+    transform_sbi_to_onnx(
+        trained_nle,
+        str(onnx_path),
+        mode="nle",
+        example_theta_dim=_THETA_DIM,
+        example_x_dim=_X_DIM,
+    )
+    model = onnx.load(str(onnx_path))
+    assert _max_int64_abs(model) <= np.iinfo(np.int32).max


### PR DESCRIPTION
## Problem

Both ONNX exporters' wrappers split the rank-1 input with an **open-ended slice** `combined[theta_dim:]` (sbi `sbi.py:170,195`; bayesflow `bayesflow.py:282,344`). `torch.onnx.export` encodes that as a `Slice` with `ends = INT64_MAX (9223372036854775807)`. A consumer that runs the graph under int32 — e.g. JAX with `jax_enable_x64=False` (HSSM's `set_floatX("float32")` path) or a non-saturating int64→int32 cast — truncates that sentinel to **−1**, turning "slice to end" into "drop the last element" and **silently corrupting the likelihood**.

(Surfaced during review of HSSM #964, whose blanket int64→int32 recast hit exactly this.)

## Fix

Use a **bounded** slice `combined[theta_dim : theta_dim + x_dim]` in all four wrappers (sbi NLE/NRE, bayesflow NLE/NRE). `combined` has exactly `theta_dim + x_dim` elements, so this is numerically identical but emits a concrete, int32-safe `ends`.

- ✅ **sbi/nflows exports become fully int32-clean** — new regression test `test_export_int64_values_fit_in_int32` asserts no int64 graph value exceeds int32 range.
- ⚠️ **bayesflow exports are still NOT int32-clean.** bayesflow's `CouplingFlow` emits its own `INT64_MAX` internally — `Slice` nodes `/inference_network/Slice_1,3` fed by `INT64_MAX` Constants from the coupling split — which this exporter **cannot** remove. Captured as a `strict=True` xfail tripwire on the bayesflow side. bayesflow ONNX therefore requires **x64 on the consumer** (HSSM relies on pytensor's `floatX→x64` contract). Tracking the upstream fix at the HSSMSpine level.

Bumps `0.7.0 → 0.7.1`.

## Test plan
- `pytest tests/test_sbi_*export.py tests/test_bayesflow_*export.py` — green (sbi int64 test passes; bayesflow int64 test xfails as documented); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app/package version to **0.7.1** and refreshed the release announcement text.

* **Bug Fixes**
  * Improved exported model handling so observation inputs use a fixed expected size during ONNX inference.
  * Reduced the risk of dimension-related issues when running exported models in different environments.

* **Tests**
  * Added regression coverage for exported ONNX models to verify integer values stay within safe bounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->