### PR TITLE
Add interactive rendering for network inspector manifold plots

### DIFF
--- a/notebooks/network_inspectors_tutorial.ipynb
+++ b/notebooks/network_inspectors_tutorial.ipynb
@@ -101,6 +101,7 @@
     "network_input: NDArray[np.float32] = np.zeros(\n",
     "    (parameter_matrix.shape[0], parameter_matrix.shape[1] + 2), dtype=np.float32\n",
     ")\n",
+    "network_input[:, :-2] = parameter_matrix\n",
     "\n",
     "# Add reaction times\n",
     "network_input[:, -2] = np.linspace(0, 3, parameter_matrix.shape[0])\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "frozendict>=2.4.6",
     "onnx>=1.17.0",
     "matplotlib>=3.10.1",
+    "plotly>=6.0.0",
     "seaborn>=0.13.2",
     "typer>=0.9.0",
 ]

--- a/src/lanfactory/network_inspectors/api.py
+++ b/src/lanfactory/network_inspectors/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pandas as pd
@@ -22,6 +22,9 @@ from .config import GridSpec, ModelSpec, PlotConfig
 from .plotting import LikelihoodResult, plot_kde_vs_lan, plot_manifold
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    import plotly.graph_objects as go
 
 
 def kde_vs_lan_likelihoods(
@@ -74,12 +77,12 @@ def lan_manifold(
     torch_mlp_predict: Callable[[NDArray[np.float32]], Any] | None = None,
     grid: GridSpec | None = None,
     plot: PlotConfig | None = None,
-) -> None:
+) -> go.Figure:
     """Plot LAN likelihoods as a 3D manifold while sweeping one parameter.
 
     parameter_df: parameter vector (first row used). vary_dict: {param: values}.
     model: model name. torch_mlp_predict: predict_on_batch from get_torch_mlp.
-    grid: optional GridSpec. plot: optional PlotConfig.
+    grid: optional GridSpec. plot: optional PlotConfig. Returns a Plotly Figure.
     """
     if parameter_df is None or torch_mlp_predict is None:
         raise ValueError(

--- a/src/lanfactory/network_inspectors/api.py
+++ b/src/lanfactory/network_inspectors/api.py
@@ -50,14 +50,22 @@ def kde_vs_lan_likelihoods(
         )
     if not isinstance(parameter_df, pd.DataFrame):
         raise TypeError("parameter_df must be a pandas.DataFrame.")
+    if parameter_df.empty:
+        raise ValueError("parameter_df must contain at least one parameter vector.")
 
     spec = ModelSpec.from_model(model, predictor=torch_mlp_predict)
+    missing_params = [param for param in spec.params if param not in parameter_df]
+    if missing_params:
+        raise ValueError(
+            "parameter_df is missing model parameter columns: "
+            + ", ".join(missing_params)
+        )
     cfg = plot or PlotConfig()
     grid_arr = make_rt_choice_grid(spec, grid)
 
     results: list[LikelihoodResult] = []
     for i in range(parameter_df.shape[0]):
-        params = parameter_df.iloc[i, :].values
+        params = parameter_df.iloc[i, :][spec.params].values.astype(np.float32)
         lan_like = np.exp(evaluate_network(spec, params, grid_arr))
         kdes = [
             np.exp(
@@ -91,6 +99,13 @@ def lan_manifold(
         )
     if vary_dict is None:
         vary_dict = {"v": [-1.0, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1.0]}
+    if len(vary_dict) != 1:
+        raise ValueError("vary_dict must contain exactly one parameter.")
+
+    vary_name, raw_values = next(iter(vary_dict.items()))
+    vary_values = np.asarray(raw_values)
+    if vary_values.size == 0:
+        raise ValueError("The parameter sweep must contain at least one value.")
 
     spec = ModelSpec.from_model(model, predictor=torch_mlp_predict)
 
@@ -101,16 +116,27 @@ def lan_manifold(
         )
 
     if isinstance(parameter_df, pd.DataFrame):
+        if parameter_df.empty:
+            raise ValueError("parameter_df must contain at least one parameter vector.")
+        missing_params = [param for param in spec.params if param not in parameter_df]
+        if missing_params:
+            raise ValueError(
+                "parameter_df is missing model parameter columns: "
+                + ", ".join(missing_params)
+            )
         if parameter_df.shape[0] > 0:
             logger.info("Using only the first row of the supplied parameter array.")
-        parameters = np.squeeze(
-            parameter_df.iloc[0, :][spec.params].values.astype(np.float32)
-        )
+        parameters = parameter_df.iloc[0, :][spec.params].values.astype(np.float32)
     else:
         parameters = np.asarray(parameter_df, dtype=np.float32)
-
-    vary_name = list(vary_dict.keys())[0]
-    vary_values = np.asarray(vary_dict[vary_name])
+        if parameters.ndim == 2:
+            if parameters.shape[0] == 0:
+                raise ValueError("parameter_df must contain at least one row.")
+            parameters = parameters[0]
+        if parameters.ndim != 1 or parameters.size != spec.n_params:
+            raise ValueError(
+                f"Expected one parameter vector with {spec.n_params} values."
+            )
 
     grid_arr = make_manifold_grid(grid or GridSpec())
     manifold = build_manifold(spec, parameters, vary_name, vary_values, grid_arr)

--- a/src/lanfactory/network_inspectors/api.py
+++ b/src/lanfactory/network_inspectors/api.py
@@ -124,7 +124,7 @@ def lan_manifold(
                 "parameter_df is missing model parameter columns: "
                 + ", ".join(missing_params)
             )
-        if parameter_df.shape[0] > 0:
+        if parameter_df.shape[0] > 1:
             logger.info("Using only the first row of the supplied parameter array.")
         parameters = parameter_df.iloc[0, :][spec.params].values.astype(np.float32)
     else:

--- a/src/lanfactory/network_inspectors/plotting.py
+++ b/src/lanfactory/network_inspectors/plotting.py
@@ -179,7 +179,7 @@ def plot_manifold(
         width=int(900 * cfg.fig_scale),
         height=int(620 * cfg.fig_scale),
         scene={
-            "xaxis_title": "RT",
+            "xaxis_title": "Signed RT",
             "yaxis_title": vary_name.upper().replace("_", "-"),
             "zaxis_title": "Likelihood",
         },
@@ -189,7 +189,7 @@ def plot_manifold(
         os.makedirs(cfg.save_dir, exist_ok=True)
         fig.write_html(
             os.path.join(cfg.save_dir, "mlp_manifold_" + spec.name + ".html"),
-            include_plotlyjs="cdn",
+            include_plotlyjs=True,
         )
 
     if cfg.show:

--- a/src/lanfactory/network_inspectors/plotting.py
+++ b/src/lanfactory/network_inspectors/plotting.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING, TypedDict
 
 import matplotlib.pyplot as plt
 import numpy as np
+import plotly.graph_objects as go
 import seaborn as sns
-from matplotlib import cm
 from numpy.typing import NDArray
 
 from .config import ModelSpec, PlotConfig
@@ -154,48 +154,45 @@ def plot_kde_vs_lan(
 
 def plot_manifold(
     manifold: pd.DataFrame, spec: ModelSpec, vary_name: str, cfg: PlotConfig
-) -> None:
-    """Render a 3D LAN likelihood manifold from a build_manifold frame."""
-    signed_rt = (manifold["rt"] * manifold["choice"]).values
-    vary = manifold["vary"].values
-    like = manifold["likelihood"].values
-
-    fig = plt.figure(figsize=(8 * cfg.fig_scale, 5.5 * cfg.fig_scale))
-    ax = fig.add_subplot(111, projection="3d")
-    ax.plot_trisurf(
-        signed_rt,
-        vary,
-        like,
-        linewidth=0.5,
-        alpha=1.0,
-        cmap=cm.coolwarm,
+) -> go.Figure:
+    """Render an interactive 3D LAN likelihood manifold."""
+    plot_data = manifold.assign(signed_rt=manifold["rt"] * manifold["choice"])
+    surface = (
+        plot_data.pivot(index="vary", columns="signed_rt", values="likelihood")
+        .sort_index()
+        .sort_index(axis=1)
     )
 
-    ax.set_ylabel(vary_name.upper().replace("_", "-"), fontsize=16, labelpad=20)
-
-    ax.set_xlabel("RT", fontsize=16, labelpad=20)
-
-    ax.set_zlabel("Likelihood", fontsize=16, labelpad=20)
-
-    ax.set_zticks(np.round(np.linspace(min(like), max(like), 5), 1))
-
-    ax.set_yticks(np.round(np.linspace(min(vary), max(vary), 5), 1))
-
-    ax.set_xticks(np.round(np.linspace(min(signed_rt), max(signed_rt), 5), 1))
-
-    ax.tick_params(labelsize=16)
-    ax.set_title(
-        spec.name.upper().replace("_", "-") + " - MLP: Manifold", fontsize=20, pad=20
+    fig = go.Figure(
+        data=[
+            go.Surface(
+                x=surface.columns.to_numpy(dtype=float),
+                y=surface.index.to_numpy(dtype=float),
+                z=surface.to_numpy(dtype=float),
+                colorscale="RdBu",
+                colorbar={"title": "Likelihood"},
+            )
+        ]
     )
-
-    ax.xaxis.set_pane_color((1.0, 1.0, 1.0, 1.0))
-    ax.yaxis.set_pane_color((1.0, 1.0, 1.0, 1.0))
-    ax.zaxis.set_pane_color((1.0, 1.0, 1.0, 1.0))
+    fig.update_layout(
+        title=spec.name.upper().replace("_", "-") + " - MLP: Manifold",
+        width=int(900 * cfg.fig_scale),
+        height=int(620 * cfg.fig_scale),
+        scene={
+            "xaxis_title": "RT",
+            "yaxis_title": vary_name.upper().replace("_", "-"),
+            "zaxis_title": "Likelihood",
+        },
+    )
 
     if cfg.save:
-        _save_figure("mlp_manifold_" + spec.name + ".png", cfg)
+        os.makedirs(cfg.save_dir, exist_ok=True)
+        fig.write_html(
+            os.path.join(cfg.save_dir, "mlp_manifold_" + spec.name + ".html"),
+            include_plotlyjs="cdn",
+        )
 
     if cfg.show:
-        plt.show()
+        fig.show()
 
-    plt.close()
+    return fig

--- a/tests/test_network_inspectors_api.py
+++ b/tests/test_network_inspectors_api.py
@@ -1,0 +1,96 @@
+"""Tests for network inspector API validation."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from lanfactory.network_inspectors import api
+
+
+def _predictor(batch: np.ndarray) -> np.ndarray:
+    return np.zeros((batch.shape[0], 1), dtype=np.float32)
+
+
+def test_kde_vs_lan_rejects_empty_parameter_frame():
+    with pytest.raises(ValueError, match="at least one parameter vector"):
+        api.kde_vs_lan_likelihoods(pd.DataFrame(), "ddm", _predictor)
+
+
+def test_kde_vs_lan_uses_model_parameter_order(monkeypatch):
+    seen_params = []
+
+    monkeypatch.setattr(api, "make_rt_choice_grid", lambda spec, grid: np.zeros((1, 2)))
+    monkeypatch.setattr(
+        api,
+        "evaluate_network",
+        lambda spec, params, grid: seen_params.append(params) or np.zeros(1),
+    )
+    monkeypatch.setattr(
+        api, "simulate_ground_truth", lambda spec, params, n_samples: {}
+    )
+    monkeypatch.setattr(api, "evaluate_kde", lambda sim_out, grid: np.zeros(1))
+    monkeypatch.setattr(api, "plot_kde_vs_lan", lambda grid, results, spec, cfg: None)
+
+    parameter_df = pd.DataFrame(
+        [{"extra": 99.0, "t": 0.3, "z": 0.5, "a": 1.5, "v": 0.2}]
+    )
+
+    api.kde_vs_lan_likelihoods(parameter_df, "ddm", _predictor, n_reps=1)
+
+    np.testing.assert_array_equal(
+        seen_params[0],
+        np.array([0.2, 1.5, 0.5, 0.3], dtype=np.float32),
+    )
+
+
+def test_lan_manifold_validates_vary_dict():
+    parameter_df = pd.DataFrame([{"v": 0.2, "a": 1.5, "z": 0.5, "t": 0.3}])
+
+    with pytest.raises(ValueError, match="exactly one parameter"):
+        api.lan_manifold(parameter_df, {}, "ddm", _predictor)
+
+    with pytest.raises(ValueError, match="exactly one parameter"):
+        api.lan_manifold(parameter_df, {"v": [0.1], "a": [1.0]}, "ddm", _predictor)
+
+    with pytest.raises(ValueError, match="at least one value"):
+        api.lan_manifold(parameter_df, {"v": []}, "ddm", _predictor)
+
+
+def test_lan_manifold_normalizes_2d_parameter_array(monkeypatch):
+    captured = {}
+
+    def build_manifold_stub(spec, parameters, vary_name, vary_values, grid):
+        captured["parameters"] = parameters
+        return pd.DataFrame(
+            {"rt": [1.0], "choice": [1], "vary": [0.2], "likelihood": [0.5]}
+        )
+
+    monkeypatch.setattr(api, "make_manifold_grid", lambda grid: np.zeros((1, 2)))
+    monkeypatch.setattr(api, "build_manifold", build_manifold_stub)
+    monkeypatch.setattr(
+        api, "plot_manifold", lambda manifold, spec, vary_name, cfg: None
+    )
+
+    api.lan_manifold(
+        np.array([[0.2, 1.5, 0.5, 0.3]], dtype=np.float32),
+        {"v": [0.2]},
+        "ddm",
+        _predictor,
+    )
+
+    np.testing.assert_array_equal(
+        captured["parameters"],
+        np.array([0.2, 1.5, 0.5, 0.3], dtype=np.float32),
+    )
+
+
+def test_lan_manifold_rejects_wrong_parameter_shape():
+    with pytest.raises(ValueError, match="Expected one parameter vector"):
+        api.lan_manifold(
+            np.array([[0.2, 1.5, 0.5]], dtype=np.float32),
+            {"v": [0.2]},
+            "ddm",
+            _predictor,
+        )

--- a/tests/test_network_inspectors_plotting.py
+++ b/tests/test_network_inspectors_plotting.py
@@ -1,0 +1,29 @@
+"""Tests for network inspector plotting helpers."""
+
+from __future__ import annotations
+
+import pandas as pd
+import plotly.graph_objects as go
+
+from lanfactory.network_inspectors.config import ModelSpec, PlotConfig
+from lanfactory.network_inspectors.plotting import plot_manifold
+
+
+def test_plot_manifold_returns_interactive_plotly_figure(tmp_path):
+    """The manifold renderer should produce an interactive Plotly surface."""
+    manifold = pd.DataFrame(
+        {
+            "rt": [1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0],
+            "choice": [-1, -1, 1, 1, -1, -1, 1, 1],
+            "vary": [0.1, 0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.2],
+            "likelihood": [0.1, 0.2, 0.3, 0.4, 0.2, 0.3, 0.4, 0.5],
+        }
+    )
+    spec = ModelSpec(name="ddm", params=["v"], choices=[-1, 1])
+    cfg = PlotConfig(show=False, save=True, save_dir=str(tmp_path))
+
+    fig = plot_manifold(manifold, spec, "v", cfg)
+
+    assert isinstance(fig, go.Figure)
+    assert fig.data[0].type == "surface"
+    assert (tmp_path / "mlp_manifold_ddm.html").exists()

--- a/tests/test_network_inspectors_plotting.py
+++ b/tests/test_network_inspectors_plotting.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pandas as pd
 import plotly.graph_objects as go
 
@@ -26,4 +27,10 @@ def test_plot_manifold_returns_interactive_plotly_figure(tmp_path):
 
     assert isinstance(fig, go.Figure)
     assert fig.data[0].type == "surface"
+    np.testing.assert_array_equal(fig.data[0].x, [-2.0, -1.0, 1.0, 2.0])
+    np.testing.assert_array_equal(fig.data[0].y, [0.1, 0.2])
+    np.testing.assert_array_equal(
+        fig.data[0].z,
+        [[0.2, 0.1, 0.3, 0.4], [0.3, 0.2, 0.4, 0.5]],
+    )
     assert (tmp_path / "mlp_manifold_ddm.html").exists()


### PR DESCRIPTION
## Summary
- Add Plotly-backed interactive 3D manifold rendering for network inspector plots
- Expose the interactive plot path through the manifold API
- Add focused API and plotting tests for the interactive surface output

## Tests
- uv run pytest tests/test_network_inspectors_api.py tests/test_network_inspectors_plotting.py
- uv run ruff format --check .
- uv run ruff check src/lanfactory
- uv run pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Network manifold visualizations now return interactive Plotly 3D charts.
  - Charts can be displayed and exported as HTML files.
- **Bug Fixes**
  - Improved preparation of model inputs so parameter portions are populated consistently for reaction-time and choice analyses.
  - Strengthened validation and deterministic failure modes for missing, empty, or incorrectly shaped parameter inputs.
- **Documentation**
  - Updated the network inspector tutorial to reflect the revised input preparation behavior.
- **Tests**
  - Added coverage for parameter validation, ordering/normalization, and Plotly figure output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->