### PR TITLE
Make training runs self-describing in MLflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.13
+    # Keep in lockstep with the dev-group pin in pyproject.toml (>=0.15.1,<0.16)
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,9 @@ dev = [
     "pytest-timer>=1.0.0",
     "pytest-xdist>=3.6.1",
     "pytest>=8.3.1",
-    "ruff>=0.14.4",
+    # <0.16: ruff 0.16 flags ~111 pre-existing errors repo-wide (same drift that
+    # broke ssm-simulators CI, pinned identically there); migrate deliberately.
+    "ruff>=0.15.1,<0.16",
     "types-PyYAML",
     "mlflow>=3.14.0",
     "jaxonnxruntime>=0.3",

--- a/src/lanfactory/cli/jax_train.py
+++ b/src/lanfactory/cli/jax_train.py
@@ -28,6 +28,7 @@ import psutil
 import typer
 from lanfactory.cli.utils import (
     _get_train_network_config,
+    log_training_run_identity,
 )
 from torch.utils.data import DataLoader
 
@@ -471,6 +472,33 @@ def main(
         ),
     )
 
+    if mlflow_tracking_enabled:
+        # Identity params/tags: make the run self-describing (model, bounds,
+        # run_uuid join key). Best-effort inside the helper.
+        log_training_run_identity(
+            model=extra_config["model"],
+            network_type=network_config["network_type"],
+            backend="jax",
+            run_uuid=RUN_ID,
+            config_path=config_path,
+            training_data_folder=training_data_folder,
+            n_training_files=n_training_files,
+            dataset=train_dataset,
+        )
+        try:
+            import mlflow
+
+            # The network config is required to reconstruct the network but was
+            # previously only written to disk, never logged — the MLflow
+            # artifact set alone could not rebuild a network.
+            mlflow.log_artifact(
+                str(networks_path / file_name_suffix), artifact_path="training_output"
+            )
+            if config_path is not None and Path(config_path).is_file():
+                mlflow.log_artifact(str(config_path), artifact_path="training_output")
+        except Exception as e:
+            logger.error("Failed to log config artifacts to MLflow: %s", e)
+
     # Load network
     net = lanfactory.trainers.JaxMLPFactory(
         network_config=deepcopy(network_config),
@@ -494,6 +522,9 @@ def main(
         mlflow_on=mlflow_tracking_enabled,
         save_outputs=True,
         verbose=1,
+        # Pass explicitly: inference from train_output_type mislabels OPN as
+        # cpn (both train on logits).
+        network_type=network_config["network_type"],
     )
     # -------------------------------------------------------------
 

--- a/src/lanfactory/cli/torch_train.py
+++ b/src/lanfactory/cli/torch_train.py
@@ -29,6 +29,7 @@ import typer
 import lanfactory
 from lanfactory.cli.utils import (
     _get_train_network_config,
+    log_training_run_identity,
 )
 
 app = typer.Typer()
@@ -474,6 +475,33 @@ def main(
             "wb",
         ),
     )
+
+    if mlflow_tracking_enabled:
+        # Identity params/tags: make the run self-describing (model, bounds,
+        # run_uuid join key). Best-effort inside the helper.
+        log_training_run_identity(
+            model=extra_config["model"],
+            network_type=network_config["network_type"],
+            backend="torch",
+            run_uuid=RUN_ID,
+            config_path=config_path,
+            training_data_folder=training_data_folder,
+            n_training_files=n_training_files,
+            dataset=train_dataset,
+        )
+        try:
+            import mlflow
+
+            # The network config is required to reconstruct the network but was
+            # previously only written to disk, never logged — the MLflow
+            # artifact set alone could not rebuild a network.
+            mlflow.log_artifact(
+                str(networks_path / file_name_suffix), artifact_path="training_output"
+            )
+            if config_path is not None and Path(config_path).is_file():
+                mlflow.log_artifact(str(config_path), artifact_path="training_output")
+        except Exception as e:
+            logger.error("Failed to log config artifacts to MLflow: %s", e)
 
     # Load network
     net = lanfactory.trainers.TorchMLP(

--- a/src/lanfactory/cli/utils.py
+++ b/src/lanfactory/cli/utils.py
@@ -202,9 +202,27 @@ def log_training_run_identity(
 
     Every field a catalog needs to answer "which network is this?" is logged on
     the run itself rather than being recoverable only from experiment-name
-    conventions or by unpickling artifacts. ``run_uuid`` is the join key
-    between the MLflow run and the artifact filenames on disk. Schema
-    documented in HSSMSpine ``_docs/mlflow-schema.md``.
+    conventions or by unpickling artifacts. Schema documented in HSSMSpine
+    ``_docs/mlflow-schema.md``.
+
+    Params vs tags split is deliberate, for resume safety: MLflow rejects
+    re-logging a param key with a *different* value, and a run resumed via
+    ``--mlflow-run-id`` re-runs this function with per-invocation values
+    (fresh ``run_uuid``, possibly different data folder / file count).
+
+    - **Params** hold facts immutable for a given network (model,
+      network_type, backend, input_dim, param_space, bounds): a resume
+      re-logs identical values, which MLflow permits.
+    - **Tags** hold per-invocation values (``run_uuid``, training data folder,
+      files used, config sha, lanfactory version): tags are mutable, so a
+      resume overwrites them and the run always reflects its *latest*
+      invocation — whose ``run_uuid`` is the one in the newest artifact
+      filenames, keeping the MLflow<->disk join correct.
+
+    Note the effective file count is tagged ``n_training_files_used``: the
+    trainer separately bulk-logs ``train_config`` whose ``n_training_files``
+    is the configured *cap*, and reusing that param key with the effective
+    value would make MLflow reject the trainer's entire param batch.
 
     Best-effort: failures are logged, never raised — training must not die on
     a tracking hiccup. No-op when no MLflow run is active.
@@ -224,21 +242,7 @@ def log_training_run_identity(
             "model": model,
             "network_type": network_type,
             "backend": backend,
-            "run_uuid": run_uuid,
-            "n_training_files": n_training_files,
         }
-        if training_data_folder is not None:
-            params["training_data_folder"] = str(training_data_folder)
-
-        if config_path is not None and Path(config_path).is_file():
-            params["config_sha256"] = hashlib.sha256(
-                Path(config_path).read_bytes()
-            ).hexdigest()
-
-        try:
-            params["lanfactory_version"] = version("lanfactory")
-        except PackageNotFoundError:
-            pass
 
         # The dataset has read a training file: it knows the exact input
         # dimensionality, and (when the data pickles embed model_config) the
@@ -263,7 +267,22 @@ def log_training_run_identity(
 
         mlflow.log_params(params)
 
-        tags = {"schema_version": "1", "phase": "train"}
+        tags = {
+            "schema_version": "1",
+            "phase": "train",
+            "run_uuid": run_uuid,
+            "n_training_files_used": str(n_training_files),
+        }
+        if training_data_folder is not None:
+            tags["training_data_folder"] = str(training_data_folder)
+        if config_path is not None and Path(config_path).is_file():
+            tags["config_sha256"] = hashlib.sha256(
+                Path(config_path).read_bytes()
+            ).hexdigest()
+        try:
+            tags["lanfactory_version"] = version("lanfactory")
+        except PackageNotFoundError:
+            pass
         for env_key, tag in (
             ("SLURM_JOB_ID", "slurm_job_id"),
             ("SLURM_ARRAY_JOB_ID", "slurm_array_job_id"),

--- a/src/lanfactory/cli/utils.py
+++ b/src/lanfactory/cli/utils.py
@@ -185,3 +185,92 @@ def _get_train_network_config(yaml_config_path: str | Path | None = None, net_in
     config["extra_fields"] = {"model": basic_config["MODEL"]}
 
     return config
+
+
+def log_training_run_identity(
+    *,
+    model: str,
+    network_type: str,
+    backend: str,
+    run_uuid: str,
+    config_path: Path | str | None,
+    training_data_folder: Path | str | None,
+    n_training_files: int,
+    dataset=None,
+) -> None:
+    """Log identity params/tags that make a training run self-describing.
+
+    Every field a catalog needs to answer "which network is this?" is logged on
+    the run itself rather than being recoverable only from experiment-name
+    conventions or by unpickling artifacts. ``run_uuid`` is the join key
+    between the MLflow run and the artifact filenames on disk. Schema
+    documented in HSSMSpine ``_docs/mlflow-schema.md``.
+
+    Best-effort: failures are logged, never raised — training must not die on
+    a tracking hiccup. No-op when no MLflow run is active.
+    """
+    import hashlib
+    import json
+    import os
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        import mlflow
+
+        if mlflow.active_run() is None:
+            return
+
+        params: dict = {
+            "model": model,
+            "network_type": network_type,
+            "backend": backend,
+            "run_uuid": run_uuid,
+            "n_training_files": n_training_files,
+        }
+        if training_data_folder is not None:
+            params["training_data_folder"] = str(training_data_folder)
+
+        if config_path is not None and Path(config_path).is_file():
+            params["config_sha256"] = hashlib.sha256(
+                Path(config_path).read_bytes()
+            ).hexdigest()
+
+        try:
+            params["lanfactory_version"] = version("lanfactory")
+        except PackageNotFoundError:
+            pass
+
+        # The dataset has read a training file: it knows the exact input
+        # dimensionality, and (when the data pickles embed model_config) the
+        # parameter space and training bounds — the fields HSSM consumers
+        # need to use a network correctly.
+        if dataset is not None:
+            input_dim = getattr(dataset, "input_dim", None)
+            if input_dim is not None:
+                params["input_dim"] = int(input_dim)
+            model_config = getattr(dataset, "data_model_config", None)
+            if isinstance(model_config, dict):
+                if "params" in model_config:
+                    params["param_space"] = json.dumps(list(model_config["params"]))
+                if "param_bounds" in model_config:
+                    bounds_json = json.dumps(
+                        np.asarray(model_config["param_bounds"]).tolist()
+                    )
+                    params["param_bounds_json"] = bounds_json
+                    params["param_bounds_sha256"] = hashlib.sha256(
+                        bounds_json.encode()
+                    ).hexdigest()
+
+        mlflow.log_params(params)
+
+        tags = {"schema_version": "1", "phase": "train"}
+        for env_key, tag in (
+            ("SLURM_JOB_ID", "slurm_job_id"),
+            ("SLURM_ARRAY_JOB_ID", "slurm_array_job_id"),
+            ("SLURM_ARRAY_TASK_ID", "slurm_array_task_id"),
+        ):
+            if os.getenv(env_key):
+                tags[tag] = os.environ[env_key]
+        mlflow.set_tags(tags)
+    except Exception as e:  # noqa: BLE001 - tracking must never kill training
+        logger.error("Failed to log run identity to MLflow: %s", e)

--- a/src/lanfactory/cli/utils.py
+++ b/src/lanfactory/cli/utils.py
@@ -281,7 +281,7 @@ def log_training_run_identity(
             ).hexdigest()
         try:
             tags["lanfactory_version"] = version("lanfactory")
-        except PackageNotFoundError:
+        except PackageNotFoundError:  # pragma: no cover - not hit under uv run
             pass
         for env_key, tag in (
             ("SLURM_JOB_ID", "slurm_job_id"),

--- a/src/lanfactory/trainers/jax_mlp.py
+++ b/src/lanfactory/trainers/jax_mlp.py
@@ -500,6 +500,7 @@ class ModelTrainerJaxMLP:
         mlflow_on: bool = False,
         save_outputs: bool = True,
         verbose: int = 1,
+        network_type: str | None = None,
     ) -> train_state.TrainState:
         """Train and evaluate JAXMLP model.
         Arguments
@@ -517,6 +518,11 @@ class ModelTrainerJaxMLP:
                 Whether to save all files or not.
             verbose (int):
                 The verbosity level.
+            network_type (str | None):
+                The network type ('lan', 'cpn', 'opn', ...), used in output
+                filenames. When None it is inferred from train_output_type —
+                which cannot distinguish cpn from opn (both use logits), so
+                callers that know the type should pass it.
         Returns
         -------
             flax.core.frozen_dict.FrozenDict:
@@ -528,18 +534,21 @@ class ModelTrainerJaxMLP:
         if mlflow_on:
             self.__try_mlflow(run_id=run_id)
 
-        # Identify network type:
-        if self.model.train_output_type == "logprob":
-            network_type = "lan"
-        elif self.model.train_output_type == "logits":
-            network_type = "cpn"
-        else:
-            network_type = "unknown"
-            print(
-                'Model type identified as "unknown" because '
-                "the training_output_type attribute"
-                ' of the supplied jax model is neither "logprob", nor "logits"'
-            )
+        # Identify network type. Inference from train_output_type is a
+        # fallback only: logits cannot distinguish cpn from opn, which used to
+        # mislabel OPN artifacts as cpn.
+        if network_type is None:
+            if self.model.train_output_type == "logprob":
+                network_type = "lan"
+            elif self.model.train_output_type == "logits":
+                network_type = "cpn"
+            else:
+                network_type = "unknown"
+                print(
+                    'Model type identified as "unknown" because '
+                    "the training_output_type attribute"
+                    ' of the supplied jax model is neither "logprob", nor "logits"'
+                )
 
         # Initialize Training history
         training_history = pd.DataFrame(
@@ -580,6 +589,21 @@ class ModelTrainerJaxMLP:
             # Collect loss in training history
             training_history.values[epoch, :] = [int(epoch), float(test_loss)]
 
+            if self.mlflow_on:
+                try:
+                    # Per-epoch metrics under the cross-backend schema names
+                    # (HSSMSpine _docs/mlflow-schema.md), matching torchtrain.
+                    # The per-100-step `loss` metric above is kept as-is.
+                    mlflow.log_metrics(
+                        {
+                            "train_loss": float(train_loss),
+                            "val_loss": float(test_loss),
+                        },
+                        step=int(epoch),
+                    )
+                except Exception:
+                    pass
+
             print(
                 "Epoch: {} / {}, test_loss: {}".format(
                     epoch, self.train_config["n_epochs"], test_loss
@@ -618,8 +642,10 @@ class ModelTrainerJaxMLP:
             pickle.dump(
                 {
                     "train_data_generator_config": self.train_dl.dataset.data_generator_config,
+                    "train_data_model_config": self.train_dl.dataset.data_model_config,
                     "train_data_file_ids": self.train_dl.dataset.file_ids,
                     "valid_data_generator_config": self.valid_dl.dataset.data_generator_config,
+                    "valid_data_model_config": self.valid_dl.dataset.data_model_config,
                     "valid_data_file_ids": self.valid_dl.dataset.file_ids,
                 },
                 open(data_details_path, "wb"),

--- a/src/lanfactory/trainers/jax_mlp.py
+++ b/src/lanfactory/trainers/jax_mlp.py
@@ -542,7 +542,8 @@ class ModelTrainerJaxMLP:
                 network_type = "lan"
             elif self.model.train_output_type == "logits":
                 network_type = "cpn"
-            else:
+            else:  # pragma: no cover - unreachable: JaxMLP.setup() raises on
+                # train_output_type values outside network_type_dict
                 network_type = "unknown"
                 print(
                     'Model type identified as "unknown" because '

--- a/src/lanfactory/trainers/torch_mlp.py
+++ b/src/lanfactory/trainers/torch_mlp.py
@@ -671,6 +671,7 @@ class ModelTrainerTorchMLP:
         for epoch in range(self.train_config["n_epochs"]):
             cnt = 0
             epoch_s_t = time()
+            epoch_loss_sum = 0.0
 
             # Training loop
             for xb, yb in self.train_dl:
@@ -692,6 +693,7 @@ class ModelTrainerTorchMLP:
                 # Log training progress
                 self._log_training_progress(epoch, cnt, loss, verbose)
 
+                epoch_loss_sum += float(loss)
                 cnt += 1
                 step_cnt += 1
 
@@ -723,16 +725,18 @@ class ModelTrainerTorchMLP:
 
             if mlflow_on:
                 try:
-                    # train_loss duplicates loss under the cross-backend schema
-                    # name (HSSMSpine _docs/mlflow-schema.md); loss is kept for
-                    # continuity with existing dashboards.
+                    # Legacy metrics unchanged (loss = last minibatch, at the
+                    # cumulative batch step). The cross-backend schema metric
+                    # train_loss (HSSMSpine _docs/mlflow-schema.md) is the
+                    # EPOCH-MEAN training loss at step=epoch, matching the jax
+                    # trainer's semantics so the two backends are comparable.
                     mlflow.log_metrics(
-                        {
-                            "loss": float(loss),
-                            "train_loss": float(loss),
-                            "val_loss": float(val_loss),
-                        },
+                        {"loss": float(loss), "val_loss": float(val_loss)},
                         step=step_cnt,
+                    )
+                    mlflow.log_metrics(
+                        {"train_loss": epoch_loss_sum / max(cnt, 1)},
+                        step=int(epoch),
                     )
                 except Exception as e:
                     logger.error(f"Unexpected mlflow error: {e}")

--- a/src/lanfactory/trainers/torch_mlp.py
+++ b/src/lanfactory/trainers/torch_mlp.py
@@ -66,6 +66,11 @@ class DatasetTorch(torch.utils.data.Dataset):
         self.label_key = label_key
         self.out_framework = out_framework
         self.data_generator_config: str = "None"
+        # model_config from the training data (param_bounds, params, choices):
+        # the provenance HSSM-facing consumers need. Populated from the first
+        # data file when present; training pickles embed it alongside
+        # generator_config (ssm-simulators lan_mlp.py).
+        self.data_model_config: str = "None"
 
         self.tmp_data: dict = {}
 
@@ -125,6 +130,9 @@ class DatasetTorch(torch.utils.data.Dataset):
 
         if "generator_config" in init_file:
             self.data_generator_config = init_file["generator_config"]
+
+        if "model_config" in init_file:
+            self.data_model_config = init_file["model_config"]
 
         if len(self.file_shape_dict["labels"]) > 1:
             self.label_dim = self.file_shape_dict["labels"][1]
@@ -715,8 +723,15 @@ class ModelTrainerTorchMLP:
 
             if mlflow_on:
                 try:
+                    # train_loss duplicates loss under the cross-backend schema
+                    # name (HSSMSpine _docs/mlflow-schema.md); loss is kept for
+                    # continuity with existing dashboards.
                     mlflow.log_metrics(
-                        {"loss": float(loss), "val_loss": float(val_loss)},
+                        {
+                            "loss": float(loss),
+                            "train_loss": float(loss),
+                            "val_loss": float(val_loss),
+                        },
                         step=step_cnt,
                     )
                 except Exception as e:
@@ -817,8 +832,10 @@ class ModelTrainerTorchMLP:
             pickle.dump(
                 {
                     "train_data_generator_config": train_dl.dataset.data_generator_config,
+                    "train_data_model_config": train_dl.dataset.data_model_config,
                     "train_datafile_ids": train_dl.dataset.file_ids,
                     "valid_data_generator_config": valid_dl.dataset.data_generator_config,
+                    "valid_data_model_config": valid_dl.dataset.data_model_config,
                     "valid_datafile_ids": valid_dl.dataset.file_ids,
                 },
                 f,

--- a/src/lanfactory/trainers/torch_mlp.py
+++ b/src/lanfactory/trainers/torch_mlp.py
@@ -23,6 +23,25 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _picklable_copy(config):
+    """Return a copy of a config dict safe for stdlib pickle.
+
+    Values that stdlib pickle rejects (e.g. local lambdas used as boundary
+    functions in ssm-simulators model configs) are replaced by their repr, so
+    provenance survives without carrying live callables.
+    """
+    if not isinstance(config, dict):
+        return config
+    out = {}
+    for key, value in config.items():
+        try:
+            pickle.dumps(value)
+            out[key] = value
+        except Exception:  # noqa: BLE001 - any unpicklable value gets repr'd
+            out[key] = repr(value)
+    return out
+
+
 class DatasetTorch(torch.utils.data.Dataset):
     """Dataset class for TorchMLP training.
 
@@ -132,7 +151,12 @@ class DatasetTorch(torch.utils.data.Dataset):
             self.data_generator_config = init_file["generator_config"]
 
         if "model_config" in init_file:
-            self.data_model_config = init_file["model_config"]
+            # Sanitized at capture: ssm-simulators model_configs can carry
+            # callables (boundary/simulator lambdas) which the training data
+            # pickles tolerate (cloudpickle) but stdlib pickle in
+            # _save_data_details cannot. The catalog-relevant fields (params,
+            # param_bounds, choices, ...) are plain data and pass through.
+            self.data_model_config = _picklable_copy(init_file["model_config"])
 
         if len(self.file_shape_dict["labels"]) > 1:
             self.label_dim = self.file_shape_dict["labels"][1]

--- a/src/lanfactory/trainers/torch_mlp.py
+++ b/src/lanfactory/trainers/torch_mlp.py
@@ -84,12 +84,12 @@ class DatasetTorch(torch.utils.data.Dataset):
         self.features_key = features_key
         self.label_key = label_key
         self.out_framework = out_framework
-        self.data_generator_config: str = "None"
+        self.data_generator_config: str | dict = "None"
         # model_config from the training data (param_bounds, params, choices):
         # the provenance HSSM-facing consumers need. Populated from the first
         # data file when present; training pickles embed it alongside
         # generator_config (ssm-simulators lan_mlp.py).
-        self.data_model_config: str = "None"
+        self.data_model_config: str | dict = "None"
 
         self.tmp_data: dict = {}
 

--- a/tests/test_run_identity.py
+++ b/tests/test_run_identity.py
@@ -307,3 +307,47 @@ class TestJaxNetworkTypePassthrough:
         names = self._train_tiny(tmp_path, network_type_arg=None)
         assert names, "no output files produced"
         assert all("_cpn_" in n for n in names), names
+
+
+class TestUnpicklableModelConfig:
+    """ssm-simulators model_configs can carry lambdas (boundary functions).
+
+    Training pickles tolerate them (cloudpickle), but data_details is written
+    with stdlib pickle — the sanitized copy must keep plain fields and
+    stringify callables. Regression test for an order-dependent failure found
+    by the full suite (race_no_bias_angle_2's lambda boundary).
+    """
+
+    def test_lambda_fields_are_stringified_and_data_details_saves(self, tmp_path):
+        import cloudpickle
+        from lanfactory.trainers.torch_mlp import ModelTrainerTorchMLP
+
+        config_with_lambda = dict(MODEL_CONFIG)
+        config_with_lambda["boundary"] = lambda t: 1.0
+
+        f = tmp_path / "training_data_lambda.pickle"
+        with open(f, "wb") as fh:
+            cloudpickle.dump(
+                {
+                    "lan_data": np.random.randn(64, 6).astype(np.float32),
+                    "lan_labels": np.random.randn(64).astype(np.float32),
+                    "generator_config": {"model": "race_no_bias_angle_2"},
+                    "model_config": config_with_lambda,
+                },
+                fh,
+            )
+
+        dataset = lanfactory.trainers.DatasetTorch(
+            file_ids=[f], batch_size=16, features_key="lan_data", label_key="lan_labels"
+        )
+        # plain fields survive, the lambda is stringified
+        assert dataset.data_model_config["params"] == MODEL_CONFIG["params"]
+        assert isinstance(dataset.data_model_config["boundary"], str)
+
+        # and the data_details write (stdlib pickle) must succeed
+        stub = SimpleNamespace(dataset=dataset)
+        out = tmp_path / "d_data_details.pickle"
+        ModelTrainerTorchMLP._save_data_details(stub, stub, str(out))
+        with open(out, "rb") as fh:
+            details = pickle.load(fh)
+        assert details["train_data_model_config"]["params"] == MODEL_CONFIG["params"]

--- a/tests/test_run_identity.py
+++ b/tests/test_run_identity.py
@@ -1,0 +1,269 @@
+"""Tests for self-describing training runs (feat/mlflow-self-describing-training).
+
+Covers:
+- ``log_training_run_identity``: the identity params/tags every training run
+  must carry (model, network_type, backend, run_uuid, bounds, ...)
+- ``DatasetTorch`` retaining ``model_config`` from training data files
+- ``_save_data_details`` carrying model_config into data_details.pickle
+- the jax trainer's ``network_type`` passthrough (OPN was mislabeled as cpn)
+"""
+
+import contextlib
+import hashlib
+import json
+import pickle
+import shutil
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+mlflow = pytest.importorskip("mlflow")
+
+import lanfactory
+from lanfactory.cli.utils import log_training_run_identity
+
+
+@pytest.fixture(scope="function", autouse=True)
+def cleanup_mlflow():
+    """Reset MLflow state after each test (mirrors test_mlflow_integration)."""
+    original_uri = mlflow.get_tracking_uri()
+    yield
+    if mlflow.active_run() is not None:
+        mlflow.end_run()
+    mlruns_path = Path.cwd() / "mlruns"
+    if mlruns_path.exists():
+        shutil.rmtree(mlruns_path)
+    with contextlib.suppress(Exception):
+        mlflow.set_tracking_uri(original_uri)
+
+
+@pytest.fixture
+def tmp_tracking(tmp_path):
+    """Isolated sqlite tracking backend."""
+    db = tmp_path / "tracking.db"
+    uri = f"sqlite:///{db.absolute()}"
+    mlflow.set_tracking_uri(uri)
+    return uri
+
+
+MODEL_CONFIG = {
+    "name": "ddm",
+    "params": ["v", "a", "z", "t"],
+    "param_bounds": [[-3.0, 0.3, 0.1, 0.0], [3.0, 2.5, 0.9, 2.0]],
+}
+
+
+def make_training_pickle(path: Path, features_key="lan_data", label_key="lan_labels"):
+    """A minimal training-data pickle shaped like ssm-simulators output."""
+    n_samples, n_features = 64, 6
+    data = {
+        features_key: np.random.randn(n_samples, n_features).astype(np.float32),
+        label_key: np.random.randn(n_samples).astype(np.float32),
+        "generator_config": {"model": "ddm", "generator_approach": "lan"},
+        "model_config": MODEL_CONFIG,
+    }
+    with open(path, "wb") as f:
+        pickle.dump(data, f)
+    return path
+
+
+class TestLogTrainingRunIdentity:
+    def _log_and_fetch(self, tmp_tracking, tmp_path, **overrides):
+        config_yaml = tmp_path / "train.yaml"
+        config_yaml.write_text("NETWORK_TYPE: lan\nMODEL: ddm\n")
+
+        dataset = SimpleNamespace(input_dim=6, data_model_config=MODEL_CONFIG)
+
+        kwargs = {
+            "model": "ddm",
+            "network_type": "lan",
+            "backend": "jax",
+            "run_uuid": "abc123",
+            "config_path": config_yaml,
+            "training_data_folder": tmp_path / "data",
+            "n_training_files": 42,
+            "dataset": dataset,
+        }
+        kwargs.update(overrides)
+
+        mlflow.set_experiment("identity-train-test")
+        with mlflow.start_run() as run:
+            log_training_run_identity(**kwargs)
+            run_id = run.info.run_id
+        return mlflow.tracking.MlflowClient().get_run(run_id)
+
+    def test_identity_params(self, tmp_tracking, tmp_path):
+        run = self._log_and_fetch(tmp_tracking, tmp_path)
+        p = run.data.params
+
+        assert p["model"] == "ddm"
+        assert p["network_type"] == "lan"
+        assert p["backend"] == "jax"
+        assert p["run_uuid"] == "abc123"
+        assert p["n_training_files"] == "42"
+        assert p["input_dim"] == "6"
+        assert json.loads(p["param_space"]) == ["v", "a", "z", "t"]
+        assert len(p["config_sha256"]) == 64
+        assert "lanfactory_version" in p
+
+    def test_param_bounds_json_and_sha_consistent(self, tmp_tracking, tmp_path):
+        run = self._log_and_fetch(tmp_tracking, tmp_path)
+        p = run.data.params
+
+        bounds = json.loads(p["param_bounds_json"])
+        assert bounds == MODEL_CONFIG["param_bounds"]
+        expected_sha = hashlib.sha256(p["param_bounds_json"].encode()).hexdigest()
+        assert p["param_bounds_sha256"] == expected_sha
+
+    def test_schema_tags(self, tmp_tracking, tmp_path):
+        run = self._log_and_fetch(tmp_tracking, tmp_path)
+        assert run.data.tags["schema_version"] == "1"
+        assert run.data.tags["phase"] == "train"
+
+    def test_no_dataset_still_logs_core_identity(self, tmp_tracking, tmp_path):
+        run = self._log_and_fetch(tmp_tracking, tmp_path, dataset=None)
+        p = run.data.params
+        assert p["model"] == "ddm"
+        assert "input_dim" not in p
+        assert "param_bounds_json" not in p
+
+    def test_dataset_without_model_config_skips_bounds(self, tmp_tracking, tmp_path):
+        # DatasetTorch defaults data_model_config to the string "None" when the
+        # training files carry no model_config — must not crash or log junk.
+        dataset = SimpleNamespace(input_dim=6, data_model_config="None")
+        run = self._log_and_fetch(tmp_tracking, tmp_path, dataset=dataset)
+        p = run.data.params
+        assert p["input_dim"] == "6"
+        assert "param_bounds_json" not in p
+
+    def test_noop_without_active_run(self, tmp_tracking, tmp_path):
+        # Must be a silent no-op, not an error.
+        assert mlflow.active_run() is None
+        log_training_run_identity(
+            model="ddm",
+            network_type="lan",
+            backend="jax",
+            run_uuid="x",
+            config_path=None,
+            training_data_folder=None,
+            n_training_files=1,
+        )
+
+
+class TestDatasetModelConfigRetention:
+    def test_model_config_retained_from_training_file(self, tmp_path):
+        f = make_training_pickle(tmp_path / "training_data_x.pickle")
+        dataset = lanfactory.trainers.DatasetTorch(
+            file_ids=[f], batch_size=16, features_key="lan_data", label_key="lan_labels"
+        )
+        assert dataset.data_model_config == MODEL_CONFIG
+        assert dataset.data_generator_config == {
+            "model": "ddm",
+            "generator_approach": "lan",
+        }
+
+    def test_absent_model_config_leaves_default(self, tmp_path):
+        f = tmp_path / "training_data_y.pickle"
+        with open(f, "wb") as fh:
+            pickle.dump(
+                {
+                    "lan_data": np.random.randn(64, 6).astype(np.float32),
+                    "lan_labels": np.random.randn(64).astype(np.float32),
+                },
+                fh,
+            )
+        dataset = lanfactory.trainers.DatasetTorch(
+            file_ids=[f], batch_size=16, features_key="lan_data", label_key="lan_labels"
+        )
+        assert dataset.data_model_config == "None"
+
+
+class TestDataDetailsCarriesModelConfig:
+    def test_torch_save_data_details_includes_model_config(self, tmp_path):
+        from lanfactory.trainers.torch_mlp import ModelTrainerTorchMLP
+
+        stub = SimpleNamespace(
+            dataset=SimpleNamespace(
+                data_generator_config={"model": "ddm"},
+                data_model_config=MODEL_CONFIG,
+                file_ids=["a.pickle"],
+            )
+        )
+        out = tmp_path / "details_data_details.pickle"
+        ModelTrainerTorchMLP._save_data_details(stub, stub, str(out))
+
+        with open(out, "rb") as f:
+            details = pickle.load(f)
+        assert details["train_data_model_config"] == MODEL_CONFIG
+        assert details["valid_data_model_config"] == MODEL_CONFIG
+
+
+class TestJaxNetworkTypePassthrough:
+    def _train_tiny(self, tmp_path, network_type_arg):
+        """One-epoch micro-training run; returns the produced filenames."""
+        from torch.utils.data import DataLoader
+
+        f = make_training_pickle(
+            tmp_path / "training_data_z.pickle",
+            features_key="opn_data",
+            label_key="opn_labels",
+        )
+        dataset = lanfactory.trainers.DatasetTorch(
+            file_ids=[f], batch_size=16, features_key="opn_data", label_key="opn_labels"
+        )
+        dl = DataLoader(dataset, batch_size=None)
+
+        net = lanfactory.trainers.JaxMLPFactory(
+            network_config={
+                "layer_sizes": [8, 1],
+                "activations": ["tanh", "linear"],
+                "train_output_type": "logits",
+                "network_type": "opn",
+            },
+            train=True,
+        )
+        # n_epochs must be >= 2: the warmup_cosine_decay schedule uses
+        # warmup_steps = len(dataset) and decay_steps = len * n_epochs, and
+        # optax requires decay_steps > warmup_steps.
+        trainer = lanfactory.trainers.ModelTrainerJaxMLP(
+            train_config={
+                "n_epochs": 2,
+                "loss": "bcelogit",
+                "optimizer": "adam",
+                "learning_rate": 0.001,
+                "lr_scheduler": None,
+                "lr_scheduler_params": {},
+                "weight_decay": 0.0,
+                "train_output_type": "logits",
+            },
+            train_dl=dl,
+            valid_dl=dl,
+            model=net,
+            seed=42,
+        )
+        out_dir = tmp_path / "nets"
+        trainer.train_and_evaluate(
+            output_folder=out_dir,
+            output_file_id="ddm",
+            run_id="runx",
+            mlflow_on=False,
+            save_outputs=True,
+            verbose=0,
+            network_type=network_type_arg,
+        )
+        return [p.name for p in out_dir.iterdir()]
+
+    def test_explicit_opn_names_files_opn(self, tmp_path):
+        names = self._train_tiny(tmp_path, network_type_arg="opn")
+        assert names, "no output files produced"
+        assert all("_opn_" in n for n in names), names
+
+    def test_fallback_infers_cpn_for_logits(self, tmp_path):
+        # Documents the legacy inference: without an explicit network_type,
+        # logits-trained networks are labeled cpn — the bug the passthrough
+        # exists to avoid.
+        names = self._train_tiny(tmp_path, network_type_arg=None)
+        assert names, "no output files produced"
+        assert all("_cpn_" in n for n in names), names

--- a/tests/test_run_identity.py
+++ b/tests/test_run_identity.py
@@ -94,19 +94,58 @@ class TestLogTrainingRunIdentity:
             run_id = run.info.run_id
         return mlflow.tracking.MlflowClient().get_run(run_id)
 
-    def test_identity_params(self, tmp_tracking, tmp_path):
+    def test_immutable_facts_are_params(self, tmp_tracking, tmp_path):
         run = self._log_and_fetch(tmp_tracking, tmp_path)
         p = run.data.params
 
         assert p["model"] == "ddm"
         assert p["network_type"] == "lan"
         assert p["backend"] == "jax"
-        assert p["run_uuid"] == "abc123"
-        assert p["n_training_files"] == "42"
         assert p["input_dim"] == "6"
         assert json.loads(p["param_space"]) == ["v", "a", "z", "t"]
-        assert len(p["config_sha256"]) == 64
-        assert "lanfactory_version" in p
+        # per-invocation values must NOT be params (resume safety)
+        for key in ("run_uuid", "n_training_files", "training_data_folder"):
+            assert key not in p
+
+    def test_per_invocation_values_are_tags(self, tmp_tracking, tmp_path):
+        run = self._log_and_fetch(tmp_tracking, tmp_path)
+        t = run.data.tags
+
+        assert t["run_uuid"] == "abc123"
+        assert t["n_training_files_used"] == "42"
+        assert "training_data_folder" in t
+        assert len(t["config_sha256"]) == 64
+        assert "lanfactory_version" in t
+
+    def test_resume_relogs_without_error_and_updates_run_uuid(
+        self, tmp_tracking, tmp_path
+    ):
+        """A resumed run re-logs identity with a fresh run_uuid: params re-log
+        identical values (allowed), tags overwrite — no MlflowException, and
+        the run reflects the latest invocation's artifacts."""
+        config_yaml = tmp_path / "train.yaml"
+        config_yaml.write_text("NETWORK_TYPE: lan\nMODEL: ddm\n")
+        dataset = SimpleNamespace(input_dim=6, data_model_config=MODEL_CONFIG)
+
+        mlflow.set_experiment("identity-resume-test")
+        with mlflow.start_run() as run:
+            for uuid_value, n_files in (("first", 2), ("second", 5)):
+                log_training_run_identity(
+                    model="ddm",
+                    network_type="lan",
+                    backend="jax",
+                    run_uuid=uuid_value,
+                    config_path=config_yaml,
+                    training_data_folder=tmp_path / "data",
+                    n_training_files=n_files,
+                    dataset=dataset,
+                )
+            run_id = run.info.run_id
+
+        fetched = mlflow.tracking.MlflowClient().get_run(run_id)
+        assert fetched.data.tags["run_uuid"] == "second"
+        assert fetched.data.tags["n_training_files_used"] == "5"
+        assert fetched.data.params["model"] == "ddm"
 
     def test_param_bounds_json_and_sha_consistent(self, tmp_tracking, tmp_path):
         run = self._log_and_fetch(tmp_tracking, tmp_path)
@@ -128,6 +167,7 @@ class TestLogTrainingRunIdentity:
         assert p["model"] == "ddm"
         assert "input_dim" not in p
         assert "param_bounds_json" not in p
+        assert run.data.tags["run_uuid"] == "abc123"
 
     def test_dataset_without_model_config_skips_bounds(self, tmp_tracking, tmp_path):
         # DatasetTorch defaults data_model_config to the string "None" when the

--- a/tests/test_run_identity.py
+++ b/tests/test_run_identity.py
@@ -19,10 +19,10 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
-mlflow = pytest.importorskip("mlflow")
-
 import lanfactory
 from lanfactory.cli.utils import log_training_run_identity
+
+mlflow = pytest.importorskip("mlflow")
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -116,6 +116,19 @@ class TestLogTrainingRunIdentity:
         assert "training_data_folder" in t
         assert len(t["config_sha256"]) == 64
         assert "lanfactory_version" in t
+
+    def test_slurm_env_ids_become_tags(self, tmp_tracking, tmp_path, monkeypatch):
+        # On Oscar these are the join keys between MLflow runs and sacct
+        # accounting; a run launched outside SLURM simply omits them.
+        monkeypatch.setenv("SLURM_JOB_ID", "12345")
+        monkeypatch.setenv("SLURM_ARRAY_JOB_ID", "12300")
+        monkeypatch.setenv("SLURM_ARRAY_TASK_ID", "7")
+        run = self._log_and_fetch(tmp_tracking, tmp_path)
+        t = run.data.tags
+
+        assert t["slurm_job_id"] == "12345"
+        assert t["slurm_array_job_id"] == "12300"
+        assert t["slurm_array_task_id"] == "7"
 
     def test_resume_relogs_without_error_and_updates_run_uuid(
         self, tmp_tracking, tmp_path
@@ -317,6 +330,13 @@ class TestUnpicklableModelConfig:
     stringify callables. Regression test for an order-dependent failure found
     by the full suite (race_no_bias_angle_2's lambda boundary).
     """
+
+    def test_non_dict_config_passes_through(self):
+        # DatasetTorch's data_model_config defaults to the string "None";
+        # the sanitizer must hand non-dict values back untouched.
+        from lanfactory.trainers.torch_mlp import _picklable_copy
+
+        assert _picklable_copy("None") == "None"
 
     def test_lambda_fields_are_stringified_and_data_details_saves(self, tmp_path):
         import cloudpickle


### PR DESCRIPTION
## What

PR-0.2 of the ecosystem's "MLflow as database of record" workstream (companion to lnccbrown/ssm-simulators#319). Training runs from both backends now carry the identity a network catalog needs, logged at the CLI level via a shared `log_training_run_identity` helper:

- **Params** (immutable network facts — safe to re-log identically on resume): `model`, `network_type`, `backend`, `input_dim`, `param_space`, `param_bounds_json` + `param_bounds_sha256`
- **Tags** (per-invocation, mutable — a resumed run overwrites them so the run reflects its latest invocation): `schema_version=1`, `phase=train`, **`run_uuid`** (the uuid in every artifact filename — the MLflow ↔ disk join key), `n_training_files_used`, `training_data_folder`, `config_sha256`, `lanfactory_version`, SLURM ids
- The params/tags split is deliberate resume-safety: MLflow rejects re-logging a param with a different value and drops the whole batch, which would silently strand the join key on `--mlflow-run-id` resumes (regression-tested)
- `network_config.pickle` + the source YAML are now logged as run artifacts (previously written to disk but never logged)
- **`param_bounds` no longer lost**: `DatasetTorch` retains `model_config` from the training data, so bounds reach `data_details.pickle` — with values sanitized for stdlib pickle (ssm-simulators pickles are cloudpickle-written and can carry lambda boundary functions; regression-tested)
- **Fixed OPN-mislabeled-as-cpn** in the jax trainer: `network_type` is threaded from `network_config` instead of being inferred from the output type (inference kept as fallback only)
- **Honest cross-backend `train_loss`**: torch now logs epoch-mean `train_loss` at `step=epoch` (matching jax) instead of last-minibatch-at-step-count; legacy `loss`/`val_loss` streams unchanged

## Ecosystem impact

Together with #319 this makes every producer run in the ecosystem self-describing under a shared `schema_version=1` schema (to be documented in HSSMSpine `_docs/mlflow-schema.md`). Downstream, LAN_pipeline_minimal's publish/registry tooling resolves artifacts via the `run_uuid` tag. Additive only; no API breaks.

## Review provenance

Adversarially reviewed pre-open (multi-agent, findings empirically reproduced). Fixed here: param-collision between identity logging and the trainer's `train_config` bulk-log (dropped the entire param batch), resume re-log raising and stranding the join key, train_loss semantics divergence, lambda-carrying model_config breaking `_save_data_details`.

## Commands run

```
uv run pytest tests/   # 206 passed, 8 skipped, 1 xfailed (full suite, incl. stacked ONNX branch)
uv run ruff check src/lanfactory && uv run ruff format --check .
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Training runs now include richer MLflow metadata, configuration, dataset details, environment information, and run identity.
  * Network and YAML configuration files are saved as MLflow artifacts when tracking is enabled.
  * JAX and PyTorch training report per-epoch training and validation metrics.
  * Saved training outputs include model configuration details for improved traceability.

* **Bug Fixes**
  * Training continues safely when MLflow artifact logging encounters an error.
  * Non-serializable configuration values are safely represented in saved metadata.

* **Chores**
  * Updated Ruff tooling to the latest supported version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->