### PR TITLE
Publish networks where HSSM actually looks for them (dual HF layout + manifest)

### DIFF
--- a/src/lanfactory/cli/upload_hf.py
+++ b/src/lanfactory/cli/upload_hf.py
@@ -106,6 +106,16 @@ def main(
         help="Fail when model_card.yaml is missing instead of generating one.",
         is_flag=True,
     ),
+    canonical_onnx: Path = typer.Option(
+        None,
+        "--canonical-onnx",
+        exists=True,
+        dir_okay=False,
+        readable=True,
+        help="Which ONNX in the model folder to publish at the repo root. "
+        "Needed when the artifact filename does not name the model (the "
+        "trainers' names do).",
+    ),
     overwrite_root: bool = typer.Option(
         False,
         "--overwrite-root",
@@ -190,6 +200,7 @@ def main(
             update_manifest=update_manifest,
             require_model_card=require_model_card,
             overwrite_root=overwrite_root,
+            canonical_onnx=canonical_onnx,
         )
 
         if url and not dry_run:

--- a/src/lanfactory/cli/upload_hf.py
+++ b/src/lanfactory/cli/upload_hf.py
@@ -88,6 +88,33 @@ def main(
         help="Show what would be uploaded without uploading.",
         is_flag=True,
     ),
+    publish_root_alias: bool = typer.Option(
+        True,
+        "--publish-root-alias/--no-publish-root-alias",
+        help="Also publish the canonical ONNX at the repo root under the "
+        "filename HSSM downloads ({model}.onnx / {model}_cpn.onnx / ...). "
+        "Without it the upload is not consumable by released HSSM versions.",
+    ),
+    update_manifest: bool = typer.Option(
+        True,
+        "--update-manifest/--no-update-manifest",
+        help="Record this network in manifest.json at the repository root.",
+    ),
+    require_model_card: bool = typer.Option(
+        False,
+        "--require-model-card",
+        help="Fail when model_card.yaml is missing instead of generating one.",
+        is_flag=True,
+    ),
+    overwrite_root: bool = typer.Option(
+        False,
+        "--overwrite-root",
+        help="Allow replacing a root network that is already published. "
+        "Released HSSM versions download root filenames from main without "
+        "pinning a revision, so replacing one changes the likelihood for all "
+        "existing users. Without this flag such an upload is refused.",
+        is_flag=True,
+    ),
     log_level: str = typer.Option(
         "WARNING",
         "--log-level",
@@ -159,6 +186,10 @@ def main(
             revision=revision,
             token=token,
             dry_run=dry_run,
+            publish_root_alias=publish_root_alias,
+            update_manifest=update_manifest,
+            require_model_card=require_model_card,
+            overwrite_root=overwrite_root,
         )
 
         if url and not dry_run:

--- a/src/lanfactory/hf/__init__.py
+++ b/src/lanfactory/hf/__init__.py
@@ -5,7 +5,10 @@ downloading models from HuggingFace Hub.
 """
 
 DEFAULT_REPO_ID = "franklab/HSSM"
-VALID_NETWORK_TYPES = ("lan", "cpn", "opn")
+# gonogo included: the trainers already build gonogo networks (cli/utils.py
+# train_output_type_dict) and HSSM resolves "{model}_gonogo.onnx", so excluding
+# it here made a trainable, loadable network type unpublishable.
+VALID_NETWORK_TYPES = ("lan", "cpn", "opn", "gonogo")
 
 from lanfactory.hf.model_card import (  # noqa: E402
     load_model_card_yaml,

--- a/src/lanfactory/hf/upload.py
+++ b/src/lanfactory/hf/upload.py
@@ -4,8 +4,8 @@ This module provides functions to upload trained LANfactory models
 to HuggingFace Hub with proper organization and metadata.
 """
 
+import json
 import logging
-import shutil
 import tempfile
 from pathlib import Path
 
@@ -19,9 +19,117 @@ DEFAULT_INCLUDE_PATTERNS = [
     "*.pt",
     "*.jax",
     "*_config.pickle",
+    "*_data_details.pickle",
+    "validation_report.json",
     "*.csv",
     "model_card.yaml",
 ]
+
+# Root-level filename suffix per network type. This mirrors HSSM's
+# ``missing_data_networks_suffix`` (src/hssm/defaults.py): HSSM builds
+# ``f"{model_name}{suffix}.onnx"`` and passes it straight to
+# ``hf_hub_download(repo_id="franklab/HSSM", filename=...)``, i.e. it resolves
+# a file at the *repository root*. Keep these in lockstep.
+ROOT_ONNX_SUFFIX = {
+    "lan": "",
+    "cpn": "_cpn",
+    "opn": "_opn",
+    "gonogo": "_gonogo",
+}
+
+MANIFEST_FILENAME = "manifest.json"
+MANIFEST_SCHEMA_VERSION = 1
+
+
+def canonical_root_filename(network_type: str, model_name: str) -> str:
+    """The repo-root filename HSSM will look for.
+
+    HSSM downloads likelihood networks by constructing this name; a network
+    uploaded only into ``{network_type}/{model_name}/`` is invisible to it.
+    """
+    if network_type not in ROOT_ONNX_SUFFIX:
+        raise ValueError(
+            f"No root filename convention for network_type {network_type!r}; "
+            f"known: {sorted(ROOT_ONNX_SUFFIX)}"
+        )
+    return f"{model_name}{ROOT_ONNX_SUFFIX[network_type]}.onnx"
+
+
+def select_canonical_onnx(files: list[Path], model_name: str) -> Path:
+    """Pick the ONNX artifact to publish at the repo root.
+
+    The chosen file is published under a name that released HSSM versions
+    download, so picking the wrong one silently swaps a production likelihood.
+    The artifact name must therefore *corroborate* ``model_name``: LANfactory's
+    trainers embed the model in every filename
+    (``{model}_{network_type}_{uuid}__model.onnx``), so a mismatch means the
+    folder and the ``--model-name`` disagree — usually a copy-paste or a
+    scripted-loop slip. Pass ``canonical_onnx=`` to override deliberately.
+    """
+    onnx_files = sorted(f for f in files if f.suffix == ".onnx")
+    if not onnx_files:
+        raise FileNotFoundError(
+            "No .onnx file found to publish at the repository root. HSSM loads "
+            "networks by their root filename, so an upload without one is not "
+            "consumable."
+        )
+
+    matching = [f for f in onnx_files if model_name in f.name]
+    if len(matching) == 1:
+        return matching[0]
+    if len(matching) > 1:
+        raise ValueError(
+            f"Cannot determine which ONNX file is canonical for {model_name!r}: "
+            f"{[f.name for f in matching]}. Upload from a folder with a single "
+            "network, or pass canonical_onnx=<path> explicitly."
+        )
+
+    raise ValueError(
+        f"No ONNX artifact in this folder names the model {model_name!r}: "
+        f"{[f.name for f in onnx_files]}. Publishing one of these at the "
+        f"repository root would overwrite {model_name}'s network with a "
+        "different model's weights. Check --model-name, or pass "
+        "canonical_onnx=<path> to override deliberately."
+    )
+
+
+def build_manifest_entry(
+    network_type: str,
+    model_name: str,
+    root_filename: str | None,
+    folder_path: str,
+    files: list[Path],
+    extra: dict | None = None,
+) -> dict:
+    """One manifest record describing a published network."""
+    entry = {
+        "model": model_name,
+        "network_type": network_type,
+        "onnx_root": root_filename,
+        "folder": folder_path,
+        "files": sorted(f.name for f in files),
+    }
+    if extra:
+        entry.update(extra)
+    return entry
+
+
+def merge_manifest(existing: dict | None, entry: dict) -> dict:
+    """Read-modify-write a root manifest, replacing any entry for this key.
+
+    Keyed by (network_type, model): re-publishing a network updates its record
+    in place rather than appending a duplicate.
+    """
+    manifest = dict(existing or {})
+    manifest["schema_version"] = MANIFEST_SCHEMA_VERSION
+    networks = list(manifest.get("networks", []))
+    key = (entry["network_type"], entry["model"])
+    networks = [n for n in networks if (n.get("network_type"), n.get("model")) != key]
+    networks.append(entry)
+    manifest["networks"] = sorted(
+        networks, key=lambda n: (n.get("network_type", ""), n.get("model", ""))
+    )
+    return manifest
 
 
 def upload_model(
@@ -37,6 +145,11 @@ def upload_model(
     revision: str | None = None,
     token: str | None = None,
     dry_run: bool = False,
+    publish_root_alias: bool = True,
+    update_manifest: bool = True,
+    require_model_card: bool = False,
+    canonical_onnx: Path | None = None,
+    overwrite_root: bool = False,
 ) -> str | None:
     """Upload a trained model to HuggingFace Hub.
 
@@ -66,6 +179,24 @@ def upload_model(
         HuggingFace API token.
     dry_run : bool
         If True, show what would be uploaded without uploading.
+    publish_root_alias : bool
+        Also publish the canonical ONNX at the repository root under the
+        filename HSSM resolves (``{model}{suffix}.onnx``). On by default: an
+        upload without it is not consumable by any released HSSM version.
+    update_manifest : bool
+        Read-modify-write ``manifest.json`` at the repository root to record
+        this network.
+    require_model_card : bool
+        Fail when ``model_card.yaml`` is absent instead of generating one from
+        the artifact pickles.
+    canonical_onnx : Path | None
+        Explicit choice of the ONNX artifact to publish at the root; inferred
+        from the folder when its name corroborates ``model_name``.
+    overwrite_root : bool
+        Allow replacing a root network that is already published. Off by
+        default: every released HSSM downloads root filenames from ``main``
+        without pinning a revision, so replacing one changes the likelihood
+        for all existing users.
 
     Returns
     -------
@@ -91,12 +222,19 @@ def upload_model(
             f"network_type must be one of {list(VALID_NETWORK_TYPES)}, got: {network_type}"
         )
 
-    # Check for model_card.yaml
+    # model_card.yaml: generate a minimal one from the artifacts when absent.
+    # The card's substance (architecture, training config) is recovered from
+    # the pickles by load_model_card_yaml's _fill_from_pickle_configs anyway,
+    # so hard-failing here blocked every automated publish for a file the
+    # library can write itself. The file is only *written* on the real upload
+    # path — a dry run must not modify the artifact folder.
     model_card_path = model_folder / "model_card.yaml"
-    if not model_card_path.exists():
+    will_generate_model_card = not model_card_path.exists()
+    if will_generate_model_card and require_model_card:
         raise FileNotFoundError(
-            f"model_card.yaml not found in {model_folder}. "
-            "Please create a model_card.yaml file with model metadata."
+            f"model_card.yaml not found in {model_folder} and "
+            "require_model_card=True. Create the file, or allow it to be "
+            "generated from the artifact configs."
         )
 
     # Use default patterns if not specified
@@ -111,9 +249,32 @@ def upload_model(
             f"No files matching patterns {include_patterns} found in {model_folder}"
         )
 
-    # Log what will be uploaded
+    # Dual layout: the full artifact set lives under {network_type}/{model}/,
+    # and the canonical ONNX is ALSO published at the repository root under
+    # the name HSSM resolves. Root placement is what every released HSSM
+    # version can actually load; the folder carries everything else.
     path_in_repo = f"{network_type}/{model_name}"
+    root_filename = None
+    root_source = None
+    if publish_root_alias:
+        root_source = (
+            Path(canonical_onnx)
+            if canonical_onnx is not None
+            else select_canonical_onnx(files_to_upload, model_name)
+        )
+        if not root_source.exists():
+            raise FileNotFoundError(f"canonical_onnx does not exist: {root_source}")
+        root_filename = canonical_root_filename(network_type, model_name)
+
     logger.info(f"Upload destination: {repo_id}/{path_in_repo}")
+    if root_filename is not None and root_source is not None and not dry_run:
+        # WARNING, not INFO: the CLI defaults to WARNING, and writing a root
+        # network is the consequential half of this operation — it must never
+        # happen silently.
+        logger.warning(
+            f"Publishing root network {repo_id}/{root_filename} "
+            f"(from {root_source.name}) — this is the file HSSM downloads."
+        )
     logger.info(f"Files to upload ({len(files_to_upload)}):")
     for f in files_to_upload:
         logger.info(f"  - {f.name}")
@@ -121,15 +282,28 @@ def upload_model(
     if dry_run:
         logger.info("DRY RUN: No files were uploaded.")
         print(
-            f"\nDRY RUN: Would upload {len(files_to_upload)} files to {repo_id}/{path_in_repo}"
+            f"\nDRY RUN: Would upload {len(files_to_upload)} files to "
+            f"{repo_id}/{path_in_repo}"
         )
         for f in files_to_upload:
             print(f"  - {f.name}")
+        if will_generate_model_card:
+            print("  - model_card.yaml (generated at upload time)")
+        if root_filename is not None and root_source is not None:
+            print(f"  - {root_filename} (root alias of {root_source.name})")
+            print(
+                f"    NOTE: {root_filename} is the file HSSM downloads for "
+                f"{model_name}. If it already exists in {repo_id}, the real "
+                "upload refuses unless --overwrite-root is given."
+            )
+        if update_manifest:
+            print(f"  - {MANIFEST_FILENAME} (updated at root)")
         return None
 
     return _upload_to_hf(  # pragma: no cover
         model_folder=model_folder,
         model_name=model_name,
+        network_type=network_type,
         files_to_upload=files_to_upload,
         path_in_repo=path_in_repo,
         repo_id=repo_id,
@@ -138,12 +312,150 @@ def upload_model(
         create_repo=create_repo,
         revision=revision,
         token=token,
+        root_filename=root_filename,
+        root_source=root_source,
+        update_manifest=update_manifest,
+        overwrite_root=overwrite_root,
+        will_generate_model_card=will_generate_model_card,
     )
+
+
+def plan_upload_placements(
+    files_to_upload: list[Path],
+    path_in_repo: str,
+    root_filename: str | None,
+    root_source: Path | None,
+    manifest_path: Path | None,
+) -> list[tuple[str, Path]]:
+    """Map every local file to its destination path in the repository.
+
+    Returns ``(path_in_repo, local_path)`` pairs: the full artifact set under
+    ``{network_type}/{model}/``, plus the canonical ONNX duplicated at the
+    root under HSSM's expected filename, plus the manifest.
+    """
+    placements: list[tuple[str, Path]] = []
+    seen: set[str] = set()
+
+    def add(destination: str, source: Path) -> None:
+        # Two operations for one destination make huggingface_hub warn and
+        # apply them in order; dedup so the payload says what it means.
+        if destination in seen:
+            return
+        seen.add(destination)
+        placements.append((destination, source))
+
+    for f in files_to_upload:
+        add(f"{path_in_repo}/{f.name}", f)
+    if root_filename is not None:
+        if root_source is None:
+            raise ValueError("root_filename given without root_source")
+        add(root_filename, root_source)
+    if manifest_path is not None:
+        add(MANIFEST_FILENAME, manifest_path)
+    return placements
+
+
+def write_default_model_card(
+    model_folder: Path, network_type: str, model_name: str
+) -> Path:
+    """Write a minimal model_card.yaml so an automated publish can proceed.
+
+    Only the descriptive shell is written here; ``load_model_card_yaml`` fills
+    architecture and training details from the artifact pickles when it reads
+    the card back.
+    """
+    import yaml
+
+    card = {
+        "tags": [network_type, "ssm", "hssm"],
+        "library_name": "onnx",
+        "license": "mit",
+        "title": f"{model_name} ({network_type.upper()})",
+        "description": (
+            f"{network_type.upper()} for the {model_name} sequential sampling "
+            "model, trained with LANfactory. This card was generated at upload "
+            "time from the training artifacts."
+        ),
+    }
+    path = model_folder / "model_card.yaml"
+    with open(path, "w") as f:
+        yaml.safe_dump(card, f, sort_keys=False)
+    return path
+
+
+class ManifestUnavailableError(RuntimeError):
+    """The existing manifest could not be read, so it cannot be updated safely."""
+
+
+class RootArtifactExistsError(RuntimeError):
+    """A root network of this name is already published and would be replaced."""
+
+
+def existing_root_filename(
+    manifest: dict | None, network_type: str, model_name: str
+) -> str | None:
+    """The root filename a previous publish recorded for this network, if any."""
+    for record in (manifest or {}).get("networks", []):
+        if (record.get("network_type"), record.get("model")) == (
+            network_type,
+            model_name,
+        ):
+            return record.get("onnx_root")
+    return None
+
+
+def list_root_files(  # pragma: no cover - network path
+    api, repo_id: str, revision: str | None
+) -> set[str]:
+    """Filenames at the repository root (no directory component)."""
+    from huggingface_hub.utils import RepositoryNotFoundError
+
+    try:
+        files = api.list_repo_files(repo_id=repo_id, revision=revision)
+    except RepositoryNotFoundError:
+        return set()  # brand-new repo: nothing to overwrite
+    return {name for name in files if "/" not in name}
+
+
+def fetch_existing_manifest(  # pragma: no cover - network path
+    repo_id: str, revision: str | None, token: str | None
+) -> dict | None:
+    """Read the current root manifest, or None when the repo genuinely has none.
+
+    The distinction matters more than it looks: the manifest is rewritten
+    wholesale from ``merge_manifest(existing, entry)``, so treating "I could
+    not tell" as "there is none" would republish a manifest listing only the
+    network being uploaded — silently erasing every previously published one.
+    Only a definitive *absent* answer returns None; anything else raises.
+    """
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError
+
+    try:
+        path = hf_hub_download(
+            repo_id=repo_id,
+            filename=MANIFEST_FILENAME,
+            revision=revision,
+            token=token,
+        )
+    except (EntryNotFoundError, RepositoryNotFoundError):
+        return None  # definitively no manifest yet
+    except Exception as e:
+        raise ManifestUnavailableError(
+            f"Could not read the existing {MANIFEST_FILENAME} from {repo_id}: "
+            f"{e}. Refusing to continue, because rewriting the manifest now "
+            "would drop every network already recorded in it. Retry when the "
+            "Hub is reachable, or pass update_manifest=False "
+            "(--no-update-manifest) to publish without touching it."
+        ) from e
+    with open(path) as f:
+        return json.load(f)
 
 
 def _upload_to_hf(  # pragma: no cover
     model_folder: Path,
     model_name: str,
+    network_type: str,
     files_to_upload: list[Path],
     path_in_repo: str,
     repo_id: str,
@@ -152,6 +464,11 @@ def _upload_to_hf(  # pragma: no cover
     create_repo: bool,
     revision: str | None,
     token: str | None,
+    root_filename: str | None = None,
+    root_source: Path | None = None,
+    update_manifest: bool = True,
+    overwrite_root: bool = False,
+    will_generate_model_card: bool = False,
 ) -> str:
     """HF-dependent implementation of upload_model."""
     try:
@@ -178,27 +495,98 @@ def _upload_to_hf(  # pragma: no cover
             logger.error(f"Failed to create repository: {e}")
             raise
 
+    # Refuse to silently replace a network that released HSSM versions are
+    # already downloading. The root namespace is shared with the legacy 2023
+    # artifacts, and HSSM resolves those names at `main` with no revision pin,
+    # so an unguarded overwrite changes the likelihood under every installed
+    # copy of HSSM on the next cache revalidation.
+    if root_filename is not None and not overwrite_root:
+        existing_root = list_root_files(api, repo_id, revision)
+        if root_filename in existing_root:
+            raise RootArtifactExistsError(
+                f"{repo_id} already publishes {root_filename} at its root, and "
+                "every released HSSM version downloads that exact file. "
+                "Replacing it changes the likelihood for all existing users. "
+                "Re-run with overwrite_root=True (--overwrite-root) if that is "
+                "intended, publish to a staging repo first "
+                "(--repo-id franklab/HSSM_staging), or pass "
+                "--no-publish-root-alias to upload the folder artifacts only."
+            )
+
+    if will_generate_model_card:
+        write_default_model_card(model_folder, network_type, model_name)
+        logger.info(f"Generated a default model_card.yaml in {model_folder}")
+        card_path = model_folder / "model_card.yaml"
+        if card_path not in files_to_upload:
+            files_to_upload.append(card_path)
+
     from lanfactory.hf.model_card import load_model_card_yaml, write_readme
 
     config = load_model_card_yaml(model_folder)
     readme_path = write_readme(model_folder, config, model_name)
-    files_to_upload.append(readme_path)
+    if readme_path not in files_to_upload:
+        files_to_upload.append(readme_path)
+
+    existing_manifest = (
+        fetch_existing_manifest(repo_id, revision, token) if update_manifest else None
+    )
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path = Path(tmp_dir)
+        manifest_path = None
+        if update_manifest:
+            entry = build_manifest_entry(
+                network_type=network_type,
+                model_name=model_name,
+                # Publishing without a root alias leaves whatever root file is
+                # already live in charge; recording null here would make the
+                # manifest misreport what HSSM actually loads.
+                root_filename=root_filename
+                or existing_root_filename(existing_manifest, network_type, model_name),
+                folder_path=path_in_repo,
+                files=files_to_upload,
+            )
+            manifest_path = tmp_path / MANIFEST_FILENAME
+            with open(manifest_path, "w") as f:
+                json.dump(merge_manifest(existing_manifest, entry), f, indent=2)
+                f.write("\n")
 
-        for file_path in files_to_upload:
-            dest = tmp_path / file_path.name
-            shutil.copy2(file_path, dest)
+        placements = plan_upload_placements(
+            files_to_upload=files_to_upload,
+            path_in_repo=path_in_repo,
+            root_filename=root_filename,
+            root_source=root_source,
+            manifest_path=manifest_path,
+        )
+
+        # One atomic commit for the folder, the root alias and the manifest.
+        # Separate calls would leave the repo in a half-published state (e.g.
+        # a root alias whose folder upload failed) that HSSM would happily
+        # download.
+        from huggingface_hub import CommitOperationAdd
+
+        operations = [
+            CommitOperationAdd(path_in_repo=dest, path_or_fileobj=str(source))
+            for dest, source in placements
+        ]
+        # parent_commit makes the write conditional: a concurrent publish that
+        # landed after we read the manifest causes a clean failure instead of
+        # silently dropping that publisher's manifest entry.
+        parent_commit = None
+        if update_manifest:
+            try:
+                parent_commit = api.repo_info(repo_id=repo_id, revision=revision).sha
+            except Exception as e:  # noqa: BLE001 - optimistic locking is a bonus
+                logger.warning(f"Could not resolve parent commit for {repo_id}: {e}")
 
         try:
-            api.upload_folder(
-                folder_path=str(tmp_path),
+            api.create_commit(
                 repo_id=repo_id,
-                path_in_repo=path_in_repo,
+                operations=operations,
                 commit_message=commit_message,
                 revision=revision,
                 token=token,
+                parent_commit=parent_commit,
             )
         except Exception as e:
             logger.error(f"Upload failed: {e}")

--- a/src/lanfactory/hf/upload.py
+++ b/src/lanfactory/hf/upload.py
@@ -6,6 +6,7 @@ to HuggingFace Hub with proper organization and metadata.
 
 import json
 import logging
+import re
 import tempfile
 from pathlib import Path
 
@@ -55,6 +56,48 @@ def canonical_root_filename(network_type: str, model_name: str) -> str:
     return f"{model_name}{ROOT_ONNX_SUFFIX[network_type]}.onnx"
 
 
+def validate_model_name(model_name: str) -> None:
+    """Reject a model name that would escape its folder or the repo root.
+
+    ``model_name`` is interpolated into both ``{network_type}/{model}/`` and
+    the root filename, so ``foo/bar`` would publish ``foo/bar.onnx`` — not at
+    the root at all, defeating the guarantee this module exists to provide.
+    """
+    if not model_name or "/" in model_name or "\\" in model_name or model_name == "..":
+        raise ValueError(
+            f"model_name must be a single path component, got {model_name!r}. "
+            "It becomes both the folder name and the root filename."
+        )
+
+
+# The two artifact-naming conventions the trainers emit. jax_mlp writes
+# "{run_id}_{network_type}_{model}__{kind}", torch_mlp writes
+# "{model}_{network_type}_{run_id}_{kind}". Both are anchored on the network
+# type, which is what lets the model field be *extracted* rather than searched
+# for. Model names contain underscores (ddm_seq2_no_bias), so a substring or
+# token search cannot tell "ddm" from "ddm_seq2" — and guessing wrong here
+# publishes one model's weights under another's root filename.
+_NT = "lan|cpn|opn|gonogo"
+_ARTIFACT_NAME_PATTERNS = (
+    re.compile(rf"^[^_]+_(?:{_NT})_(?P<model>.+?)__"),  # jax
+    re.compile(rf"^(?P<model>.+?)_(?:{_NT})_[^_]+_"),  # torch
+)
+
+
+def names_model(filename: str, model_name: str) -> bool:
+    """Whether an artifact filename names exactly this model.
+
+    Returns False for names that follow no known convention: the caller then
+    demands an explicit ``canonical_onnx``, which is the safe default for a
+    file about to be published under a name released HSSM versions download.
+    """
+    return any(
+        match.group("model") == model_name
+        for match in (p.match(filename) for p in _ARTIFACT_NAME_PATTERNS)
+        if match
+    )
+
+
 def select_canonical_onnx(files: list[Path], model_name: str) -> Path:
     """Pick the ONNX artifact to publish at the repo root.
 
@@ -74,7 +117,7 @@ def select_canonical_onnx(files: list[Path], model_name: str) -> Path:
             "consumable."
         )
 
-    matching = [f for f in onnx_files if model_name in f.name]
+    matching = [f for f in onnx_files if names_model(f.name, model_name)]
     if len(matching) == 1:
         return matching[0]
     if len(matching) > 1:
@@ -222,6 +265,8 @@ def upload_model(
             f"network_type must be one of {list(VALID_NETWORK_TYPES)}, got: {network_type}"
         )
 
+    validate_model_name(model_name)
+
     # model_card.yaml: generate a minimal one from the artifacts when absent.
     # The card's substance (architecture, training config) is recovered from
     # the pickles by load_model_card_yaml's _fill_from_pickle_configs anyway,
@@ -264,6 +309,16 @@ def upload_model(
         )
         if not root_source.exists():
             raise FileNotFoundError(f"canonical_onnx does not exist: {root_source}")
+        # The root alias must also exist inside the published folder, or the
+        # manifest would record a folder that does not contain the network
+        # HSSM actually downloads.
+        if root_source.resolve().parent != model_folder.resolve():
+            raise ValueError(
+                f"canonical_onnx must live in {model_folder}, got {root_source}. "
+                "The root alias is a copy of a folder artifact; publishing a "
+                "file from elsewhere would leave the folder without the "
+                "network recorded in the manifest."
+            )
         root_filename = canonical_root_filename(network_type, model_name)
 
     logger.info(f"Upload destination: {repo_id}/{path_in_repo}")
@@ -495,13 +550,23 @@ def _upload_to_hf(  # pragma: no cover
             logger.error(f"Failed to create repository: {e}")
             raise
 
+    # Resolve the parent commit BEFORE reading anything: a publish that lands
+    # between the read and the commit must invalidate our parent, otherwise the
+    # optimistic lock accepts the write and drops the other publisher's entry.
+    parent_commit = None
+    if update_manifest:
+        try:
+            parent_commit = api.repo_info(repo_id=repo_id, revision=revision).sha
+        except Exception as e:  # noqa: BLE001 - optimistic locking is a bonus
+            logger.warning(f"Could not resolve parent commit for {repo_id}: {e}")
+
     # Refuse to silently replace a network that released HSSM versions are
     # already downloading. The root namespace is shared with the legacy 2023
     # artifacts, and HSSM resolves those names at `main` with no revision pin,
     # so an unguarded overwrite changes the likelihood under every installed
     # copy of HSSM on the next cache revalidation.
     if root_filename is not None and not overwrite_root:
-        existing_root = list_root_files(api, repo_id, revision)
+        existing_root = list_root_files(api, repo_id, parent_commit or revision)
         if root_filename in existing_root:
             raise RootArtifactExistsError(
                 f"{repo_id} already publishes {root_filename} at its root, and "
@@ -528,7 +593,10 @@ def _upload_to_hf(  # pragma: no cover
         files_to_upload.append(readme_path)
 
     existing_manifest = (
-        fetch_existing_manifest(repo_id, revision, token) if update_manifest else None
+        # Read at the pinned revision so the manifest and the parent match.
+        fetch_existing_manifest(repo_id, parent_commit or revision, token)
+        if update_manifest
+        else None
     )
 
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -569,16 +637,6 @@ def _upload_to_hf(  # pragma: no cover
             CommitOperationAdd(path_in_repo=dest, path_or_fileobj=str(source))
             for dest, source in placements
         ]
-        # parent_commit makes the write conditional: a concurrent publish that
-        # landed after we read the manifest causes a clean failure instead of
-        # silently dropping that publisher's manifest entry.
-        parent_commit = None
-        if update_manifest:
-            try:
-                parent_commit = api.repo_info(repo_id=repo_id, revision=revision).sha
-            except Exception as e:  # noqa: BLE001 - optimistic locking is a bonus
-                logger.warning(f"Could not resolve parent commit for {repo_id}: {e}")
-
         try:
             api.create_commit(
                 repo_id=repo_id,

--- a/tests/cli/test_hf_cli.py
+++ b/tests/cli/test_hf_cli.py
@@ -132,8 +132,9 @@ class TestUploadHfDryRun:
         with open(yaml_path, "w", encoding="utf-8") as f:
             yaml.dump(yaml_content, f)
 
-        # Create a dummy model file
-        (tmp_path / "model.onnx").write_text("dummy content")
+        # Dummy artifact named the way the trainers name them: the model name
+        # must appear in the filename, or the root-alias selection refuses.
+        (tmp_path / "abc_lan_test-model__model.onnx").write_text("dummy content")
 
         result = subprocess.run(
             [
@@ -154,8 +155,13 @@ class TestUploadHfDryRun:
         assert result.returncode == 0
         assert "DRY RUN" in result.stdout
 
-    def test_dry_run_missing_model_card(self, tmp_path):
-        """Test dry run fails when model_card.yaml is missing."""
+    def test_dry_run_missing_model_card_no_longer_blocks(self, tmp_path):
+        """A missing model_card.yaml no longer blocks the run.
+
+        This folder still fails, but on the thing that actually matters — it
+        holds no artifacts at all. And the dry run leaves the folder untouched:
+        the card is written only on a real upload.
+        """
         result = subprocess.run(
             [
                 "upload-hf",
@@ -173,7 +179,53 @@ class TestUploadHfDryRun:
         )
 
         assert result.returncode != 0
-        assert (
-            "model_card.yaml not found" in result.stderr
-            or "model_card.yaml not found" in result.stdout
+        combined = result.stdout + result.stderr
+        assert "No files matching patterns" in combined
+        assert "model_card.yaml not found" not in combined
+        assert not (tmp_path / "model_card.yaml").exists()
+
+    def test_dry_run_leaves_the_artifact_folder_untouched(self, tmp_path):
+        (tmp_path / "abc_lan_test-model__model.onnx").write_text("dummy")
+        before = sorted(p.name for p in tmp_path.iterdir())
+
+        result = subprocess.run(
+            [
+                "upload-hf",
+                "--model-folder",
+                str(tmp_path),
+                "--network-type",
+                "lan",
+                "--model-name",
+                "test-model",
+                "--dry-run",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
         )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert sorted(p.name for p in tmp_path.iterdir()) == before
+
+    def test_dry_run_missing_model_card_with_require_flag(self, tmp_path):
+        """--require-model-card restores the old hard failure."""
+        (tmp_path / "model.onnx").write_text("content")
+        result = subprocess.run(
+            [
+                "upload-hf",
+                "--model-folder",
+                str(tmp_path),
+                "--network-type",
+                "lan",
+                "--model-name",
+                "test-model",
+                "--dry-run",
+                "--require-model-card",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode != 0
+        assert "model_card.yaml not found" in result.stdout + result.stderr

--- a/tests/hf/test_dual_layout.py
+++ b/tests/hf/test_dual_layout.py
@@ -1,0 +1,629 @@
+"""Tests for the dual HF layout (feat/hf-dual-layout-upload).
+
+The load-bearing property: whatever else an upload writes, the canonical ONNX
+must land at the repository *root* under the exact filename HSSM constructs.
+HSSM does `hf_hub_download(repo_id="franklab/HSSM", filename=f"{model}{suffix}.onnx")`,
+so a network published only into `{network_type}/{model}/` is invisible to it —
+which is what the previous upload path did.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lanfactory.hf.upload import (
+    MANIFEST_FILENAME,
+    ROOT_ONNX_SUFFIX,
+    build_manifest_entry,
+    canonical_root_filename,
+    merge_manifest,
+    plan_upload_placements,
+    select_canonical_onnx,
+    upload_model,
+    write_default_model_card,
+)
+
+
+@pytest.fixture
+def model_folder(tmp_path):
+    """A trained-network folder shaped like the trainers' output."""
+    folder = tmp_path / "ddm"
+    folder.mkdir()
+    (folder / "abc123_lan_ddm__model.onnx").write_bytes(b"onnx-bytes")
+    (folder / "abc123_lan_ddm__train_state.jax").write_bytes(b"jax-bytes")
+    (folder / "abc123_lan_ddm__network_config.pickle").write_bytes(b"pickle")
+    (folder / "abc123_lan_ddm__data_details.pickle").write_bytes(b"pickle")
+    (folder / "validation_report.json").write_text('{"gates": {}}')
+    (folder / "abc123_lan_ddm__training_history.csv").write_text("epoch,loss\n")
+    return folder
+
+
+def install_fake_hub(monkeypatch, root_files=(), commits=None, repo_sha="abc"):
+    """Register a stub huggingface_hub (plus .utils) and capture commits."""
+    import sys
+
+    class FakeApi:
+        def __init__(self, token=None):
+            pass
+
+        def list_repo_files(self, repo_id, revision=None):
+            return list(root_files) + ["lan/other/x.onnx"]
+
+        def repo_info(self, repo_id, revision=None):
+            return type("Info", (), {"sha": repo_sha})()
+
+        def create_commit(self, **kwargs):
+            if commits is not None:
+                # Snapshot payload bytes now: real huggingface_hub reads the
+                # files during the commit, while ours live in a
+                # TemporaryDirectory that is gone once upload_model returns.
+                for op in kwargs["operations"]:
+                    source = Path(op.path_or_fileobj)
+                    op.content = source.read_bytes() if source.exists() else None
+                commits.append(kwargs)
+
+    class FakeOperationAdd:
+        def __init__(self, path_in_repo, path_or_fileobj):
+            self.path_in_repo = path_in_repo
+            self.path_or_fileobj = path_or_fileobj
+
+    class FakeRepositoryNotFoundError(Exception):
+        pass
+
+    utils = type("Utils", (), {"RepositoryNotFoundError": FakeRepositoryNotFoundError})
+    hub = type(
+        "FakeHub",
+        (),
+        {
+            "HfApi": FakeApi,
+            "create_repo": lambda **kwargs: None,
+            "CommitOperationAdd": FakeOperationAdd,
+            "utils": utils,
+        },
+    )
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+    monkeypatch.setitem(sys.modules, "huggingface_hub.utils", utils)
+    return hub
+
+
+class TestCanonicalRootFilename:
+    @pytest.mark.parametrize(
+        ("network_type", "expected"),
+        [
+            ("lan", "ddm.onnx"),
+            ("cpn", "ddm_cpn.onnx"),
+            ("opn", "ddm_opn.onnx"),
+            ("gonogo", "ddm_gonogo.onnx"),
+        ],
+    )
+    def test_matches_hssm_lookup(self, network_type, expected):
+        assert canonical_root_filename(network_type, "ddm") == expected
+
+    def test_suffix_map_matches_hssm_source(self):
+        """Guard against drift from HSSM's missing_data_networks_suffix.
+
+        Skips when HSSM is not importable — this repo does not depend on it.
+        """
+        hssm_defaults = pytest.importorskip("hssm.defaults")
+        hssm_suffixes = {
+            key.name.lower(): value
+            for key, value in hssm_defaults.missing_data_networks_suffix.items()
+        }
+        # HSSM's NONE (no missing-data network) is our plain "lan" case.
+        expected = {
+            "lan": hssm_suffixes["none"],
+            "cpn": hssm_suffixes["cpn"],
+            "opn": hssm_suffixes["opn"],
+            "gonogo": hssm_suffixes["gonogo"],
+        }
+        assert ROOT_ONNX_SUFFIX == expected
+
+    def test_unknown_network_type_rejected(self):
+        with pytest.raises(ValueError, match="No root filename convention"):
+            canonical_root_filename("nope", "ddm")
+
+
+class TestSelectCanonicalOnnx:
+    def test_single_onnx_selected(self, tmp_path):
+        onnx = tmp_path / "a_lan_ddm__model.onnx"
+        onnx.write_bytes(b"x")
+        other = tmp_path / "a_lan_ddm__train_state.jax"
+        other.write_bytes(b"x")
+        assert select_canonical_onnx([onnx, other], "ddm") == onnx
+
+    def test_no_onnx_is_an_error(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="No .onnx file"):
+            select_canonical_onnx([tmp_path / "x.jax"], "ddm")
+
+    def test_single_onnx_of_a_different_model_is_refused(self, tmp_path):
+        """A wrong --model-name must not publish another model's weights.
+
+        The root filename is what released HSSM downloads, so accepting an
+        angle network as `ddm.onnx` would silently swap a production
+        likelihood. The trainers always embed the model in the filename, so a
+        mismatch is a real signal.
+        """
+        onnx = tmp_path / "run7_lan_angle__model.onnx"
+        onnx.write_bytes(b"ANGLE")
+        with pytest.raises(ValueError, match="No ONNX artifact in this folder"):
+            select_canonical_onnx([onnx], "ddm")
+
+    def test_ambiguous_onnx_refuses_to_guess(self, tmp_path):
+        # Publishing the wrong network under the canonical name would be
+        # silent and wrong; fail instead.
+        a = tmp_path / "ddm_a.onnx"
+        b = tmp_path / "ddm_b.onnx"
+        a.write_bytes(b"x")
+        b.write_bytes(b"x")
+        with pytest.raises(ValueError, match="Cannot determine which ONNX"):
+            select_canonical_onnx([a, b], "ddm")
+
+    def test_model_name_disambiguates(self, tmp_path):
+        mine = tmp_path / "run_lan_ddm__model.onnx"
+        other = tmp_path / "run_lan_angle__model.onnx"
+        mine.write_bytes(b"x")
+        other.write_bytes(b"x")
+        assert select_canonical_onnx([mine, other], "ddm") == mine
+
+
+class TestPlacements:
+    def test_root_alias_duplicates_the_folder_artifact(self, tmp_path):
+        onnx = tmp_path / "abc_lan_ddm__model.onnx"
+        onnx.write_bytes(b"x")
+        placements = plan_upload_placements(
+            files_to_upload=[onnx],
+            path_in_repo="lan/ddm",
+            root_filename="ddm.onnx",
+            root_source=onnx,
+            manifest_path=None,
+        )
+        destinations = [dest for dest, _ in placements]
+        assert "lan/ddm/abc_lan_ddm__model.onnx" in destinations
+        assert "ddm.onnx" in destinations
+        # same local file published twice, under both names
+        sources = {dest: src for dest, src in placements}
+        assert sources["ddm.onnx"] == sources["lan/ddm/abc_lan_ddm__model.onnx"]
+
+    def test_manifest_goes_to_root(self, tmp_path):
+        onnx = tmp_path / "m.onnx"
+        onnx.write_bytes(b"x")
+        manifest = tmp_path / MANIFEST_FILENAME
+        manifest.write_text("{}")
+        placements = plan_upload_placements(
+            files_to_upload=[onnx],
+            path_in_repo="lan/ddm",
+            root_filename=None,
+            root_source=None,
+            manifest_path=manifest,
+        )
+        assert (MANIFEST_FILENAME, manifest) in placements
+
+    def test_root_filename_without_source_is_a_bug(self, tmp_path):
+        with pytest.raises(ValueError, match="without root_source"):
+            plan_upload_placements([], "lan/ddm", "ddm.onnx", None, None)
+
+
+class TestManifestMerge:
+    def entry(self, model="ddm", network_type="lan"):
+        return build_manifest_entry(
+            network_type=network_type,
+            model_name=model,
+            root_filename=canonical_root_filename(network_type, model),
+            folder_path=f"{network_type}/{model}",
+            files=[Path("a.onnx")],
+        )
+
+    def test_creates_manifest_from_nothing(self):
+        merged = merge_manifest(None, self.entry())
+        assert merged["schema_version"] == 1
+        assert [n["model"] for n in merged["networks"]] == ["ddm"]
+
+    def test_republish_replaces_rather_than_duplicates(self):
+        first = merge_manifest(None, self.entry())
+        updated = build_manifest_entry(
+            network_type="lan",
+            model_name="ddm",
+            root_filename="ddm.onnx",
+            folder_path="lan/ddm",
+            files=[Path("a.onnx"), Path("b.pickle")],
+        )
+        merged = merge_manifest(first, updated)
+        assert len(merged["networks"]) == 1
+        assert merged["networks"][0]["files"] == ["a.onnx", "b.pickle"]
+
+    def test_other_networks_are_preserved(self):
+        first = merge_manifest(None, self.entry(model="angle"))
+        merged = merge_manifest(first, self.entry(model="ddm"))
+        assert [n["model"] for n in merged["networks"]] == ["angle", "ddm"]
+
+    def test_same_model_different_network_type_coexists(self):
+        first = merge_manifest(None, self.entry(model="ddm", network_type="lan"))
+        merged = merge_manifest(first, self.entry(model="ddm", network_type="cpn"))
+        assert {(n["network_type"], n["model"]) for n in merged["networks"]} == {
+            ("lan", "ddm"),
+            ("cpn", "ddm"),
+        }
+
+    def test_unknown_top_level_keys_survive(self):
+        existing = {"networks": [], "generated_by": "someone else"}
+        merged = merge_manifest(existing, self.entry())
+        assert merged["generated_by"] == "someone else"
+
+
+class TestModelCardGeneration:
+    def test_missing_card_is_generated_on_the_real_upload(
+        self, model_folder, monkeypatch
+    ):
+        """Generated on upload, not on dry run (see TestDryRunPurity)."""
+        import lanfactory.hf.upload as upload_module
+
+        assert not (model_folder / "model_card.yaml").exists()
+        TestProductionSafety().fake_hub(monkeypatch)
+        monkeypatch.setattr(
+            upload_module, "fetch_existing_manifest", lambda *a, **k: None
+        )
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            repo_id="franklab/HSSM_staging",
+        )
+        card_path = model_folder / "model_card.yaml"
+        assert card_path.exists()
+        card = yaml.safe_load(card_path.read_text())
+        assert "ddm" in card["title"]
+        assert "lan" in card["tags"]
+
+    def test_require_model_card_restores_hard_failure(self, model_folder):
+        with pytest.raises(FileNotFoundError, match="require_model_card=True"):
+            upload_model(
+                model_folder=model_folder,
+                network_type="lan",
+                model_name="ddm",
+                dry_run=True,
+                require_model_card=True,
+            )
+
+    def test_existing_card_is_not_overwritten(self, model_folder):
+        card = model_folder / "model_card.yaml"
+        card.write_text(yaml.safe_dump({"title": "hand written"}))
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            dry_run=True,
+        )
+        assert yaml.safe_load(card.read_text())["title"] == "hand written"
+
+    def test_generated_card_is_loadable(self, model_folder):
+        from lanfactory.hf.model_card import load_model_card_yaml
+
+        write_default_model_card(model_folder, "cpn", "angle")
+        config = load_model_card_yaml(model_folder)
+        assert "angle" in config.title
+
+
+class TestDryRunReporting:
+    def test_dry_run_names_the_root_alias_and_manifest(self, model_folder, capsys):
+        upload_model(
+            model_folder=model_folder,
+            network_type="cpn",
+            model_name="ddm",
+            dry_run=True,
+        )
+        out = capsys.readouterr().out
+        assert "ddm_cpn.onnx (root alias" in out
+        assert MANIFEST_FILENAME in out
+
+    def test_opting_out_reports_no_alias(self, model_folder, capsys):
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            dry_run=True,
+            publish_root_alias=False,
+            update_manifest=False,
+        )
+        out = capsys.readouterr().out
+        assert "root alias" not in out
+        assert MANIFEST_FILENAME not in out
+
+    def test_new_artifacts_are_included(self, model_folder, capsys):
+        # data_details carries param_bounds; validation_report carries the gate
+        # results — both are needed by the registry and were previously dropped.
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            dry_run=True,
+        )
+        out = capsys.readouterr().out
+        assert "abc123_lan_ddm__data_details.pickle" in out
+        assert "validation_report.json" in out
+
+
+class TestUploadCommit:
+    """The upload itself, with huggingface_hub stubbed out."""
+
+    def test_single_atomic_commit_contains_folder_root_and_manifest(
+        self, model_folder, monkeypatch
+    ):
+        import lanfactory.hf.upload as upload_module
+
+        commits = []
+        install_fake_hub(monkeypatch, commits=commits)
+        monkeypatch.setattr(
+            upload_module, "fetch_existing_manifest", lambda *a, **k: None
+        )
+
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            repo_id="franklab/HSSM_staging",
+        )
+
+        assert len(commits) == 1, "upload must be one atomic commit"
+        destinations = {op.path_in_repo for op in commits[0]["operations"]}
+        assert "ddm.onnx" in destinations, "root alias missing — HSSM cannot load it"
+        assert MANIFEST_FILENAME in destinations
+        assert "lan/ddm/abc123_lan_ddm__model.onnx" in destinations
+        assert "lan/ddm/abc123_lan_ddm__data_details.pickle" in destinations
+
+    def test_manifest_content_written_to_the_commit(self, model_folder, monkeypatch):
+        import lanfactory.hf.upload as upload_module
+
+        commits = []
+        install_fake_hub(monkeypatch, commits=commits)
+        # an existing manifest with another network already published
+        monkeypatch.setattr(
+            upload_module,
+            "fetch_existing_manifest",
+            lambda *a, **k: {
+                "schema_version": 1,
+                "networks": [{"model": "angle", "network_type": "lan"}],
+            },
+        )
+
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            repo_id="franklab/HSSM_staging",
+        )
+
+        manifest_op = next(
+            op
+            for op in commits[0]["operations"]
+            if op.path_in_repo == MANIFEST_FILENAME
+        )
+        manifest = json.loads(manifest_op.content)
+        models = {n["model"] for n in manifest["networks"]}
+        assert models == {"angle", "ddm"}, "existing entries must survive"
+        ddm = next(n for n in manifest["networks"] if n["model"] == "ddm")
+        assert ddm["onnx_root"] == "ddm.onnx"
+        assert ddm["folder"] == "lan/ddm"
+
+
+class TestProductionSafety:
+    """Guards on writes that reach every installed copy of HSSM.
+
+    Root filenames are resolved by HSSM at `main` with no revision pin, so
+    replacing one changes the likelihood for all existing users on their next
+    cache revalidation.
+    """
+
+    def fake_hub(self, monkeypatch, root_files=(), commits=None, repo_sha="abc"):
+        return install_fake_hub(monkeypatch, root_files, commits, repo_sha)
+
+    def test_existing_root_network_is_not_silently_replaced(
+        self, model_folder, monkeypatch
+    ):
+        import lanfactory.hf.upload as upload_module
+
+        self.fake_hub(monkeypatch, root_files=["ddm.onnx"])
+        monkeypatch.setattr(
+            upload_module, "fetch_existing_manifest", lambda *a, **k: None
+        )
+        with pytest.raises(
+            upload_module.RootArtifactExistsError, match="overwrite-root"
+        ):
+            upload_model(
+                model_folder=model_folder,
+                network_type="lan",
+                model_name="ddm",
+                repo_id="franklab/HSSM",
+            )
+
+    def test_overwrite_root_allows_the_replacement(self, model_folder, monkeypatch):
+        import lanfactory.hf.upload as upload_module
+
+        commits = []
+        self.fake_hub(monkeypatch, root_files=["ddm.onnx"], commits=commits)
+        monkeypatch.setattr(
+            upload_module, "fetch_existing_manifest", lambda *a, **k: None
+        )
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            repo_id="franklab/HSSM",
+            overwrite_root=True,
+        )
+        assert "ddm.onnx" in {op.path_in_repo for op in commits[0]["operations"]}
+
+    def test_first_publish_of_a_new_model_is_allowed(self, model_folder, monkeypatch):
+        import lanfactory.hf.upload as upload_module
+
+        commits = []
+        self.fake_hub(monkeypatch, root_files=["angle.onnx"], commits=commits)
+        monkeypatch.setattr(
+            upload_module, "fetch_existing_manifest", lambda *a, **k: None
+        )
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            repo_id="franklab/HSSM",
+        )
+        assert "ddm.onnx" in {op.path_in_repo for op in commits[0]["operations"]}
+
+    def test_commit_is_conditional_on_the_parent(self, model_folder, monkeypatch):
+        """Concurrent publishes must fail loudly, not drop each other's entries."""
+        import lanfactory.hf.upload as upload_module
+
+        commits = []
+        self.fake_hub(monkeypatch, commits=commits, repo_sha="parent-sha")
+        monkeypatch.setattr(
+            upload_module, "fetch_existing_manifest", lambda *a, **k: None
+        )
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            repo_id="franklab/HSSM_staging",
+        )
+        assert commits[0]["parent_commit"] == "parent-sha"
+
+
+class TestManifestSafety:
+    def test_unreadable_manifest_aborts_instead_of_wiping(
+        self, model_folder, monkeypatch
+    ):
+        """A transient Hub failure must not erase every published network.
+
+        merge_manifest rewrites the file wholesale, so "could not read" must
+        never be treated as "there is none".
+        """
+        import lanfactory.hf.upload as upload_module
+
+        def boom(*a, **k):
+            raise upload_module.ManifestUnavailableError("503 Service Unavailable")
+
+        monkeypatch.setattr(upload_module, "fetch_existing_manifest", boom)
+        TestProductionSafety().fake_hub(monkeypatch)
+        with pytest.raises(upload_module.ManifestUnavailableError):
+            upload_model(
+                model_folder=model_folder,
+                network_type="lan",
+                model_name="ddm",
+                repo_id="franklab/HSSM",
+            )
+
+    def test_absent_manifest_still_starts_a_new_one(self, model_folder, monkeypatch):
+        import lanfactory.hf.upload as upload_module
+
+        commits = []
+        TestProductionSafety().fake_hub(monkeypatch, commits=commits)
+        monkeypatch.setattr(
+            upload_module, "fetch_existing_manifest", lambda *a, **k: None
+        )
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            repo_id="franklab/HSSM_staging",
+        )
+        assert MANIFEST_FILENAME in {op.path_in_repo for op in commits[0]["operations"]}
+
+    def test_no_root_alias_keeps_the_recorded_onnx_root(
+        self, model_folder, monkeypatch
+    ):
+        """Re-publishing without an alias must not claim onnx_root: null.
+
+        The previously published root file stays live and is still what HSSM
+        loads; recording null would make the manifest misreport reality.
+        """
+        import lanfactory.hf.upload as upload_module
+
+        commits = []
+        TestProductionSafety().fake_hub(monkeypatch, commits=commits)
+        monkeypatch.setattr(
+            upload_module,
+            "fetch_existing_manifest",
+            lambda *a, **k: {
+                "schema_version": 1,
+                "networks": [
+                    {"model": "ddm", "network_type": "lan", "onnx_root": "ddm.onnx"}
+                ],
+            },
+        )
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            repo_id="franklab/HSSM_staging",
+            publish_root_alias=False,
+        )
+        manifest_op = next(
+            op
+            for op in commits[0]["operations"]
+            if op.path_in_repo == MANIFEST_FILENAME
+        )
+        manifest = json.loads(manifest_op.content)
+        ddm = next(n for n in manifest["networks"] if n["model"] == "ddm")
+        assert ddm["onnx_root"] == "ddm.onnx"
+
+
+class TestDryRunPurity:
+    def test_dry_run_does_not_write_into_the_artifact_folder(self, model_folder):
+        before = sorted(p.name for p in model_folder.iterdir())
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            dry_run=True,
+        )
+        assert sorted(p.name for p in model_folder.iterdir()) == before
+        assert not (model_folder / "model_card.yaml").exists()
+
+    def test_dry_run_announces_the_generated_card(self, model_folder, capsys):
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            dry_run=True,
+        )
+        assert "model_card.yaml (generated at upload time)" in capsys.readouterr().out
+
+    def test_dry_run_warns_about_root_replacement(self, model_folder, capsys):
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            dry_run=True,
+        )
+        out = capsys.readouterr().out
+        assert "--overwrite-root" in out
+
+    def test_failed_dry_run_leaves_nothing_behind(self, tmp_path):
+        folder = tmp_path / "empty_but_carded"
+        folder.mkdir()
+        (folder / "notes.csv").write_text("x\n")
+        with pytest.raises(FileNotFoundError, match="No .onnx file"):
+            upload_model(
+                model_folder=folder,
+                network_type="lan",
+                model_name="ddm",
+                dry_run=True,
+            )
+        assert not (folder / "model_card.yaml").exists()
+
+
+class TestPlacementDedup:
+    def test_duplicate_destinations_are_collapsed(self, tmp_path):
+        onnx = tmp_path / "ddm.onnx"
+        onnx.write_bytes(b"x")
+        readme = tmp_path / "README.md"
+        readme.write_text("stale")
+        placements = plan_upload_placements(
+            files_to_upload=[onnx, readme, readme],
+            path_in_repo="lan/ddm",
+            root_filename="ddm.onnx",
+            root_source=onnx,
+            manifest_path=None,
+        )
+        destinations = [dest for dest, _ in placements]
+        assert len(destinations) == len(set(destinations))

--- a/tests/hf/test_dual_layout.py
+++ b/tests/hf/test_dual_layout.py
@@ -19,6 +19,7 @@ from lanfactory.hf.upload import (
     build_manifest_entry,
     canonical_root_filename,
     merge_manifest,
+    names_model,
     plan_upload_placements,
     select_canonical_onnx,
     upload_model,
@@ -151,10 +152,11 @@ class TestSelectCanonicalOnnx:
             select_canonical_onnx([onnx], "ddm")
 
     def test_ambiguous_onnx_refuses_to_guess(self, tmp_path):
-        # Publishing the wrong network under the canonical name would be
-        # silent and wrong; fail instead.
-        a = tmp_path / "ddm_a.onnx"
-        b = tmp_path / "ddm_b.onnx"
+        # Two runs of the same model in one folder: both legitimately name
+        # ddm, so there is no basis to pick one. Publishing either under the
+        # canonical name would be a silent coin flip; fail instead.
+        a = tmp_path / "run1_lan_ddm__model.onnx"
+        b = tmp_path / "run2_lan_ddm__model.onnx"
         a.write_bytes(b"x")
         b.write_bytes(b"x")
         with pytest.raises(ValueError, match="Cannot determine which ONNX"):
@@ -627,3 +629,122 @@ class TestPlacementDedup:
         )
         destinations = [dest for dest, _ in placements]
         assert len(destinations) == len(set(destinations))
+
+
+class TestReviewFixes:
+    """Regressions for the CodeRabbit/Copilot findings on #110."""
+
+    @pytest.mark.parametrize(
+        ("filename", "model", "expected"),
+        [
+            ("abc123_lan_ddm__model.onnx", "ddm", True),  # jax convention
+            ("ddm_lan_abc123_model.onnx", "ddm", True),  # torch convention
+            ("run_lan_ddm_seq2__model.onnx", "ddm", False),  # prefix, not the model
+            ("run_lan_ddm2__model.onnx", "ddm", False),  # prefix, not the model
+            ("run_lan_ddm_seq2__model.onnx", "ddm_seq2", True),  # underscored name
+            ("model.onnx", "ddm", False),  # no convention -> explicit choice
+        ],
+    )
+    def test_model_match_is_exact_not_substring(self, filename, model, expected):
+        # A substring test made "ddm" match ddm_seq2/ddm2 and publish another
+        # model's weights as ddm.onnx — the swap this guard exists to stop.
+        assert names_model(filename, model) is expected
+
+    @pytest.mark.parametrize("bad", ["foo/bar", "..", "a\\b", ""])
+    def test_model_name_must_be_one_path_component(self, model_folder, bad):
+        # model_name becomes both the folder and the root filename, so a
+        # separator would publish outside the root entirely.
+        with pytest.raises(ValueError, match="single path component"):
+            upload_model(
+                model_folder=model_folder,
+                network_type="lan",
+                model_name=bad,
+                dry_run=True,
+            )
+
+    def test_canonical_onnx_outside_the_folder_is_rejected(
+        self, model_folder, tmp_path
+    ):
+        # Otherwise the root gets a network the published folder does not
+        # contain, and the manifest records a folder that lacks it.
+        stray = tmp_path / "elsewhere.onnx"
+        stray.write_bytes(b"x")
+        with pytest.raises(ValueError, match="must live in"):
+            upload_model(
+                model_folder=model_folder,
+                network_type="lan",
+                model_name="ddm",
+                dry_run=True,
+                canonical_onnx=stray,
+            )
+
+    def test_canonical_onnx_inside_the_folder_is_accepted(self, model_folder):
+        chosen = model_folder / "abc123_lan_ddm__model.onnx"
+        assert (
+            upload_model(
+                model_folder=model_folder,
+                network_type="lan",
+                model_name="ddm",
+                dry_run=True,
+                canonical_onnx=chosen,
+            )
+            is None
+        )
+
+    def test_gonogo_is_uploadable(self, tmp_path):
+        # ROOT_ONNX_SUFFIX claimed gonogo support while VALID_NETWORK_TYPES
+        # rejected it, so a trainable, HSSM-loadable type was unpublishable.
+        folder = tmp_path / "gonogo"
+        folder.mkdir()
+        (folder / "abc_gonogo_ddm__model.onnx").write_bytes(b"x")
+        assert (
+            upload_model(
+                model_folder=folder,
+                network_type="gonogo",
+                model_name="ddm",
+                dry_run=True,
+            )
+            is None
+        )
+
+    def test_parent_commit_is_resolved_before_the_manifest_is_read(
+        self, model_folder, monkeypatch
+    ):
+        """Order matters: reading first would let a concurrent publish slip in
+        between the read and the parent, and the lock would accept the write."""
+        import lanfactory.hf.upload as upload_module
+
+        calls = []
+        commits = []
+        install_fake_hub(monkeypatch, commits=commits, repo_sha="sha1")
+
+        real_repo_info_marker = "repo_info"
+
+        def spy_fetch(repo_id, revision, token):
+            calls.append(("fetch_manifest", revision))
+            return None
+
+        monkeypatch.setattr(upload_module, "fetch_existing_manifest", spy_fetch)
+
+        import huggingface_hub
+
+        original = huggingface_hub.HfApi.repo_info
+
+        def spy_repo_info(self, repo_id, revision=None):
+            calls.append((real_repo_info_marker, revision))
+            return original(self, repo_id, revision)
+
+        monkeypatch.setattr(huggingface_hub.HfApi, "repo_info", spy_repo_info)
+
+        upload_model(
+            model_folder=model_folder,
+            network_type="lan",
+            model_name="ddm",
+            repo_id="franklab/HSSM_staging",
+        )
+
+        kinds = [c[0] for c in calls]
+        assert kinds.index("repo_info") < kinds.index("fetch_manifest")
+        # and the manifest is read AT that parent, not at the moving branch
+        assert dict(calls)["fetch_manifest"] == "sha1"
+        assert commits[0]["parent_commit"] == "sha1"

--- a/tests/hf/test_upload.py
+++ b/tests/hf/test_upload.py
@@ -95,13 +95,19 @@ class TestUploadModel:
                 model_name="ddm",
             )
 
-    def test_raises_if_model_card_missing(self, tmp_path):
-        """Test raises FileNotFoundError if model_card.yaml is missing."""
+    def test_raises_if_model_card_missing_and_required(self, tmp_path):
+        """A missing model_card.yaml is only fatal on request.
+
+        It used to be fatal always, which blocked automated publishing for a
+        file the library can generate from the artifacts; the strict behavior
+        now lives behind require_model_card (see tests/hf/test_dual_layout.py).
+        """
         with pytest.raises(FileNotFoundError, match="model_card.yaml not found"):
             upload_model(
                 model_folder=tmp_path,
                 network_type="lan",
                 model_name="ddm",
+                require_model_card=True,
             )
 
     def test_raises_if_no_matching_files(self, tmp_path):
@@ -129,8 +135,8 @@ class TestUploadModel:
         with open(yaml_path, "w") as f:
             yaml.dump(yaml_content, f)
 
-        # Create a model file
-        (tmp_path / "model.onnx").write_text("onnx content")
+        # Artifact named the way the trainers name them (model in the filename)
+        (tmp_path / "abc_lan_ddm__model.onnx").write_text("onnx content")
 
         result = upload_model(
             model_folder=tmp_path,
@@ -140,6 +146,36 @@ class TestUploadModel:
         )
 
         assert result is None
+
+    def test_generically_named_onnx_needs_an_explicit_choice(self, tmp_path):
+        """A filename that does not name the model must be opted into.
+
+        The root filename is what HSSM downloads, so an artifact that cannot
+        corroborate --model-name is not published by guesswork.
+        """
+        (tmp_path / "model_card.yaml").write_text(yaml.dump({"title": "T"}))
+        onnx = tmp_path / "model.onnx"
+        onnx.write_text("onnx content")
+
+        with pytest.raises(ValueError, match="No ONNX artifact in this folder"):
+            upload_model(
+                model_folder=tmp_path,
+                network_type="lan",
+                model_name="ddm",
+                dry_run=True,
+            )
+
+        # ...and the override works
+        assert (
+            upload_model(
+                model_folder=tmp_path,
+                network_type="lan",
+                model_name="ddm",
+                dry_run=True,
+                canonical_onnx=onnx,
+            )
+            is None
+        )
 
     @requires_hf
     @patch("huggingface_hub.HfApi")
@@ -152,19 +188,21 @@ class TestUploadModel:
         yaml_content = {"tags": ["lan", "ssm"], "title": "Test"}
         with open(tmp_path / "model_card.yaml", "w") as f:
             yaml.dump(yaml_content, f)
-        (tmp_path / "model.onnx").write_text("content")
+        (tmp_path / "abc_lan_ddm__model.onnx").write_text("content")
 
         # Mock API
         mock_api = MagicMock()
         mock_api_class.return_value = mock_api
+        mock_api.list_repo_files.return_value = []
 
-        upload_model(
-            model_folder=tmp_path,
-            network_type="lan",
-            model_name="ddm",
-            create_repo=True,
-            token="fake_token",
-        )
+        with patch("lanfactory.hf.upload.fetch_existing_manifest", return_value=None):
+            upload_model(
+                model_folder=tmp_path,
+                network_type="lan",
+                model_name="ddm",
+                create_repo=True,
+                token="fake_token",
+            )
 
         mock_create_repo.assert_called_once()
 
@@ -172,29 +210,37 @@ class TestUploadModel:
     @patch("huggingface_hub.HfApi")
     @patch("huggingface_hub.create_repo")
     def test_uploads_to_correct_path(self, mock_create_repo, mock_api_class, tmp_path):
-        """Test files are uploaded to correct path in repo."""
+        """Files land under {network_type}/{model} in one commit.
+
+        The upload is a single create_commit rather than upload_folder, so the
+        folder, the root alias and the manifest cannot land separately (see
+        tests/hf/test_dual_layout.py for the layout assertions).
+        """
         # Create model_card.yaml
         yaml_content = {"tags": ["lan", "ssm"], "title": "Test"}
         with open(tmp_path / "model_card.yaml", "w") as f:
             yaml.dump(yaml_content, f)
-        (tmp_path / "model.onnx").write_text("content")
+        (tmp_path / "abc_lan_ddm__model.onnx").write_text("content")
 
         # Mock API
         mock_api = MagicMock()
         mock_api_class.return_value = mock_api
+        mock_api.list_repo_files.return_value = []
 
-        upload_model(
-            model_folder=tmp_path,
-            network_type="lan",
-            model_name="ddm",
-            repo_id="test/repo",
-        )
+        with patch("lanfactory.hf.upload.fetch_existing_manifest", return_value=None):
+            upload_model(
+                model_folder=tmp_path,
+                network_type="lan",
+                model_name="ddm",
+                repo_id="test/repo",
+            )
 
-        # Check upload_folder was called with correct path
-        mock_api.upload_folder.assert_called_once()
-        call_kwargs = mock_api.upload_folder.call_args[1]
-        assert call_kwargs["path_in_repo"] == "lan/ddm"
+        mock_api.create_commit.assert_called_once()
+        call_kwargs = mock_api.create_commit.call_args[1]
         assert call_kwargs["repo_id"] == "test/repo"
+        destinations = {op.path_in_repo for op in call_kwargs["operations"]}
+        assert "lan/ddm/abc_lan_ddm__model.onnx" in destinations
+        assert "ddm.onnx" in destinations  # root alias HSSM resolves
 
 
 class TestDefaults:


### PR DESCRIPTION
## What

PR-1.2 of the laptop→Oscar pipeline workstream.

`upload_model` wrote everything into `{network_type}/{model}/`. HSSM loads networks with `hf_hub_download(repo_id="franklab/HSSM", filename=f"{model}{suffix}.onnx")` — a file at the **repository root**. So the upload module, which nothing had ever called end-to-end, produced output no released HSSM could consume.

**Dual layout:** the full artifact set stays in the folder, and the canonical ONNX is also published at the root under HSSM's filename, plus a root `manifest.json`.

## Verified against the real consumer

The suffix map (`""`/`_cpn`/`_opn`/`_gonogo`) is cross-checked in a test against HSSM's own `missing_data_networks_suffix`. It `importorskip`s HSSM (this repo doesn't depend on it), so I ran it once under `uv run --with hssm` — **it passes against actual HSSM**, not against my reading of it.

## Production safety

This writes to a repo that every installed HSSM downloads from, at `main`, with **no revision pin**. An adversarial review found my first version would have replaced production networks silently. Fixed, each with a regression test:

- **Refuses to replace an existing root network** unless `--overwrite-root`. The root namespace is shared with the 18 legacy 2023 artifacts; replacing one changes the likelihood for every existing user on their next cache revalidation. First publish of a new model is unaffected.
- **The root write logs at WARNING, not INFO.** The CLI defaults to `--log-level WARNING`, so the consequential half of the operation was previously invisible; the only output pointed at the folder.
- **The selected ONNX must corroborate `--model-name`.** A folder holding `run7_lan_angle__model.onnx` uploaded as `--model-name ddm` used to publish an angle network as `ddm.onnx`. Now refused, with `canonical_onnx=` as the deliberate override.
- **An unreadable existing manifest aborts.** `merge_manifest` rewrites the file wholesale, so treating "couldn't reach the Hub" as "no manifest" would have republished a manifest listing only the current network — erasing every other entry, exit code 0.
- **`create_commit` passes `parent_commit`**, so concurrent publishes (a post-sweep batch) fail loudly instead of dropping each other's manifest entries.
- **`--dry-run` no longer writes into the artifact folder** (it used to drop `model_card.yaml` there, even on the failure path).
- Everything lands in **one atomic commit** — separate calls could leave a root alias pointing at a network whose folder upload failed.

## Also

- `*_data_details.pickle` (carries `param_bounds`) and `validation_report.json` added to the include patterns — both needed by the registry, previously dropped.
- `model_card.yaml` generated from the artifacts when absent instead of hard-failing, which had blocked every automated publish; strict behavior moved behind `--require-model-card`.
- New flags: `--publish-root-alias/--no-...`, `--update-manifest/--no-...`, `--require-model-card`, `--overwrite-root`.

## Behavior changes to review deliberately

Three existing tests encoded old behavior and were updated rather than worked around: the model-card hard failure (now `require_model_card=True`), the `upload_folder` assertion (now the atomic commit), and fixtures using a generic `model.onnx` (now trainer-style names, since a generic name can no longer be auto-selected for a root publish).

## Commands run

```
uv run pytest tests/ -q            # 250 passed, 9 skipped, 1 xfailed
uv run pytest tests/hf tests/cli/test_hf_cli.py -q   # 91 passed
uv run --with hssm pytest tests/hf/test_dual_layout.py -k suffix_map   # cross-check vs real HSSM
uv run ruff check . && uv run ruff format --check .
```

Reviewed adversarially across three lenses (production-data safety, the HSSM contract, code edges): 23 findings, 13 confirmed after independent verification, all fixed here. No network calls to huggingface.co were made — `HfApi` was stubbed throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added options for root-level ONNX aliases, manifest updates, model-card requirements, canonical ONNX selection, and controlled overwrites.
  * Added automatic model-card generation and dry-run reporting for planned uploads.
  * Added support for publishing `gonogo` networks.
  * Added atomic uploads with duplicate and overwrite protection.

* **Bug Fixes**
  * Improved handling of missing model cards, manifest reads, and ambiguous ONNX filenames.
  * Prevented unsafe replacement of existing root artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->