### PR TITLE
docs: phase-0 safety net — fix config rot, strict build in CI, deploy workflow, redirects, link check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,12 +5,16 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - "pyproject.toml"
+      - "lanfactory/**"
   push:
     branches:
       - main
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - "pyproject.toml"
+      - "lanfactory/**"
   release:
     types:
       - published
@@ -18,6 +22,9 @@ on:
     # Weekly link check, Monday 06:17 UTC (off-peak).
     - cron: "17 6 * * 1"
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,90 @@
+name: Docs
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+  release:
+    types:
+      - published
+  schedule:
+    # Weekly link check, Monday 06:17 UTC (off-peak).
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  build:
+    # Strict build: any mkdocs warning (broken nav entry, bad link, autorefs
+    # duplicate, deprecated option) fails the job.
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install docs dependencies
+        run: uv sync --group docs
+
+      - name: Build docs (strict)
+        run: uv run mkdocs build --strict
+
+  deploy:
+    # Deploy the live site on release, on docs changes landing in main, or on
+    # manual dispatch — never for PRs.
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      - name: Install docs dependencies
+        run: uv sync --group docs
+
+      - name: Deploy docs to GitHub Pages
+        run: uv run mkdocs gh-deploy --force
+
+  linkcheck:
+    # External links rot independently of code changes, so this runs on a
+    # weekly schedule (plus manual dispatch) rather than on every PR.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Check links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --no-progress "docs/**/*.md" "README.md"
+          fail: true

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,8 @@
+# URLs excluded from the weekly lychee link check (.github/workflows/docs.yml).
+# One URL or regex per line.
+
+# Local MLflow UI address used in the MLflow guide — never reachable from CI.
+http://localhost:5000
+
+# doi.org rate-limits anonymous CI requests, producing flaky 429s.
+https://doi.org/.*

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ neural likelihood (NLE) and neural ratio (NRE) estimators, producing files
 HSSM can consume via its `loglik_kind="approx_differentiable"` path. See the
 [Exporting sbi Models guide](docs/exporting_sbi_models.md).
 
-Please find the original [documentation here](https://alexanderfengler.github.io/LANfactory/).
+Please find the original [documentation here](https://lnccbrown.github.io/LANfactory/).
 
 ### Cite LANfactory
 

--- a/docs/api/lanfactory.md
+++ b/docs/api/lanfactory.md
@@ -1,1 +1,0 @@
-:::lanfactory

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
-site_name: LANFactory
-repo_name: AlexanderFengler/LANFactory
-repo_url: htps://github.com/AlexanderFengler/LANFactory
+site_name: LANfactory
+site_url: https://lnccbrown.github.io/LANfactory/
+repo_name: lnccbrown/LANfactory
+repo_url: https://github.com/lnccbrown/LANfactory
 edit_uri: edit/main/docs
 
 nav:
@@ -19,16 +20,23 @@ nav:
       - Exporting sbi Models: exporting_sbi_models.md
       - Exporting bayesflow Models: exporting_bayesflow_models.md
   - API:
-      - lanfactory: api/lanfactory.md
       - config: api/config.md
       - hf: api/hf.md
       - onnx: api/onnx.md
       - trainers: api/trainers.md
       - utils: api/utils.md
 
+validation:
+  omitted_files: warn
+  absolute_links: warn
+  unrecognized_links: warn
+  anchors: warn
+
 plugins:
   - search
   - autorefs
+  - redirects:
+      redirect_maps: {}
   - mkdocs-jupyter:
       execute: True
       execute_ignore:
@@ -104,7 +112,7 @@ theme:
         name: Switch to automatic mode
 
 extra:
-  homepage: "https://AlexanderFengler.github.io/LANFactory/"
+  homepage: "https://lnccbrown.github.io/LANfactory/"
 
 extra_css:
   - "styles/extra.css"
@@ -120,5 +128,5 @@ markdown_extensions:
   - pymdownx.superfences
   - attr_list
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,18 @@ dev = [
     "sbi>=0.26",
     "marimo>=0.23",
 ]
+docs = [
+    "mkdocs>=1.6",
+    "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.26",
+    "mkdocs-jupyter>=0.25",
+    "mkdocs-autorefs>=1.2",
+    # <1.2.3: the 1.2.3 release (2026-03-28) adds a dependency on "properdocs",
+    # an MkDocs impostor fork that injects a deceptive migration banner into
+    # every build. 1.2.2 depends only on mkdocs. Bump deliberately, after
+    # verifying upstream has removed the properdocs dependency.
+    "mkdocs-redirects>=1.2,<1.2.3",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
- Fix mkdocs.yml config rot: typo'd dead \`repo_url\` (\`htps://…AlexanderFengler/LANFactory\`), stale repo_name/site_name/homepage → \`lnccbrown/LANfactory\`; add \`site_url\`.
- Replace deprecated \`materialx.emoji\` with \`material.extensions.emoji\`.
- Add \`validation:\` block (warn) and \`mkdocs-redirects\` plugin with an empty map, ready for future page moves.
- Remove \`docs/api/lanfactory.md\` (\`:::lanfactory\` aggregate) — it double-documented every object next to the per-module API pages, causing 14 autorefs "Multiple primary URLs" warnings. \`mkdocs build --strict\` now passes with **zero warnings** (was 15).
- Add a \`docs\` dependency group (mkdocs, material, mkdocstrings[python], jupyter, autorefs, redirects). **Note:** \`mkdocs-redirects\` is pinned \`<1.2.3\` — the 1.2.3 release (2026-03-28) added a dependency on \`properdocs\`, an MkDocs impostor fork that injects a deceptive "MkDocs is abandoned, switch to ProperDocs" banner into every build. 1.2.2 is clean (depends only on mkdocs).
- New \`.github/workflows/docs.yml\`: strict build on docs PRs/main/release; \`gh-deploy\` after green build on release/main/dispatch (also refreshes the stale live site, which is missing the Guides tab); weekly lychee link check over docs + README with a root \`.lycheeignore\`.
- README docs link → https://lnccbrown.github.io/LANfactory/.

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation and repository links to the current project locations.
  * Reorganized API navigation into focused sections for configuration, Hugging Face, ONNX, trainers, and utilities.
  * Improved documentation validation, redirects, homepage metadata, and emoji rendering.
  * Added documentation build dependencies.

* **Chores**
  * Added automated documentation builds, deployment, and scheduled external-link checks.
  * Excluded known local and DOI links from automated link validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->