### PR TITLE
docs: adopt the shared ecosystem brand bundle (phase 1)

### DIFF
--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -1,1 +1,3 @@
 :::lanfactory.config
+
+:::lanfactory.config.network_configs

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,7 +1,9 @@
 {#- HSSM ecosystem shared announcement banner.
-    SOURCE OF TRUTH: HSSMSpine/docs-brand/main.html — synced by
-    scripts/sync_docs_brand.py; do not edit the vendored copies.
-    Repo-agnostic: all links derive from config.repo_url. -#}
+    VENDORED COPY — source of truth: https://github.com/lnccbrown/HSSMSpine
+    (docs-brand/main.html). Edit there and re-sync; local edits will be
+    flagged as drift. Repo-agnostic: the release link derives from
+    config.repo_url; questions route to the ecosystem's shared forum
+    (HSSM Discussions) by design. -#}
 {% extends "base.html" %}
 {% block announce %}
 <span class="show-on-small right-margin">

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,5 +1,8 @@
+{#- HSSM ecosystem shared announcement banner.
+    SOURCE OF TRUTH: HSSMSpine/docs-brand/main.html — synced by
+    scripts/sync_docs_brand.py; do not edit the vendored copies.
+    Repo-agnostic: all links derive from config.repo_url. -#}
 {% extends "base.html" %}
-
 {% block announce %}
 <span class="show-on-small right-margin">
     <span class="twemoji right-margin show-on-small move-down">
@@ -8,11 +11,17 @@
     Navigate the site here!
 </span>
 <span class="right-margin">
-    <a href="https://github.com/lnccbrown/LANfactory/releases/latest">v0.8.0 is out!</a>
+    <a href="{{ config.repo_url | trim('/') }}/releases/latest">
+        A new release is out — read the release notes
+    </a>
 </span>
 <span>
     <span class="twemoji">
         {% include ".icons/material/head-question.svg" %}
     </span>
+    Questions?
+    <a href="https://github.com/lnccbrown/HSSM/discussions">
+        Open a discussion!
+    </a>
 </span>
 {% endblock %}

--- a/docs/styles/extra.css
+++ b/docs/styles/extra.css
@@ -1,6 +1,7 @@
 /* HSSM ecosystem brand tokens + shared helpers.
-   SOURCE OF TRUTH: HSSMSpine/docs-brand/extra.css — synced into each repo by
-   scripts/sync_docs_brand.py; do not edit the vendored copies. */
+   VENDORED COPY — source of truth: https://github.com/lnccbrown/HSSMSpine
+   (docs-brand/extra.css). Edit there and re-sync; local edits will be
+   flagged as drift. */
 
 /* -- palette (ocean = light/auto, slate = dark) -- */
 [data-md-color-scheme="ocean"] {
@@ -57,10 +58,6 @@ div .jp-RenderedText {
   width: 200px;
 }
 
-.md-header-__title {
-  font-size: 1rem;
-}
-
 div .md-sidebar__inner {
   margin-left: 0.2rem;
 }
@@ -97,10 +94,10 @@ div .md-sidebar__inner nav .md-nav__list {
 
 .move-down {
   transform: translate(0px, -5px);
-  animation: down_movement 1000ms infinite ease-out;
+  animation: down-movement 1000ms infinite ease-out;
 }
 
-@keyframes down_movement {
+@keyframes down-movement {
   to {
     transform: translate(0px, 5px);
   }

--- a/docs/styles/extra.css
+++ b/docs/styles/extra.css
@@ -1,3 +1,8 @@
+/* HSSM ecosystem brand tokens + shared helpers.
+   SOURCE OF TRUTH: HSSMSpine/docs-brand/extra.css — synced into each repo by
+   scripts/sync_docs_brand.py; do not edit the vendored copies. */
+
+/* -- palette (ocean = light/auto, slate = dark) -- */
 [data-md-color-scheme="ocean"] {
   --md-primary-fg-color: #245c81;
   --md-accent-fg-color: #ec205b;
@@ -8,4 +13,101 @@
   --md-primary-fg-color: #245c81;
   --md-accent-fg-color: #ec205b;
   --md-typeset-a-color: #00b4b5;
+}
+
+/* -- shared typography -- */
+.md-typeset h1 {
+  font-weight: 300;
+}
+
+h2 {
+  font-weight: 700;
+}
+
+.md-typeset code {
+  font-size: 0.7rem;
+}
+
+.md-typeset table:not([class]) {
+  font-size: 0.7rem;
+}
+
+/* -- notebook output sizing (was inline in HSSM's main.html) -- */
+pre {
+  font-size: 0.7rem;
+}
+
+.jp-OutputArea-executeResult pre,
+.jp-xr-text-repr-fallback pre,
+.jupyter-wrapper .jp-RenderedText pre {
+  font-size: 0.7rem !important;
+}
+
+.xr-sections {
+  font-size: 0.7rem;
+}
+
+div .jp-RenderedText {
+  font-size: 0.7rem !important;
+}
+
+/* -- header/sidebar tweaks -- */
+.md-header-nav__title img {
+  height: 200px;
+  width: 200px;
+}
+
+.md-header-__title {
+  font-size: 1rem;
+}
+
+div .md-sidebar__inner {
+  margin-left: 0.2rem;
+}
+
+div .md-sidebar__inner nav .md-nav__list {
+  margin-left: 0.2rem;
+}
+
+/* -- landing-page grid -- */
+#wrapper {
+  display: grid;
+  grid-template-columns: 33.334% 66.667%;
+}
+
+#main-logo {
+  text-align: center;
+}
+
+#main-title {
+  padding-top: 1.3em;
+  padding-left: 1em;
+}
+
+/* -- announcement-banner helpers (used by the shared main.html) -- */
+.right-margin {
+  margin-right: 10px;
+}
+
+@media screen and (min-width: 1220px) {
+  .show-on-small {
+    display: none;
+  }
+}
+
+.move-down {
+  transform: translate(0px, -5px);
+  animation: down_movement 1000ms infinite ease-out;
+}
+
+@keyframes down_movement {
+  to {
+    transform: translate(0px, 5px);
+  }
+}
+
+.question {
+  color: pink;
+  width: 35px;
+  height: 35px;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,28 +50,36 @@ plugins:
       default_handler: python
       handlers:
         python:
-          import:
+          inventories:
             - https://docs.python.org/3/objects.inv
             - https://mkdocstrings.github.io/objects.inv
             - https://mkdocstrings.github.io/griffe/objects.inv
           options:
-            show_submodules: true
             separate_signature: true
             merge_init_into_class: true
             docstring_options:
               ignore_init_summary: true
-            docstring_style: "numpy"
-            docstring_section_style: "list"
+            docstring_style: numpy
+            docstring_section_style: list
             show_root_members_full_path: true
             show_object_full_path: false
-            show_category_heading: true
-            show_signature_annotations: false
+            show_category_heading: false
+            show_signature_annotations: true
+            show_docstring_attributes: false
             show_source: false
-            group_by_category: false
-            signature_crossrefs: true
+            show_root_heading: true
+            group_by_category: true
+            signature_crossrefs: false
+            summary: true
+            line_length: 80
+            unwrap_annotated: false
+            modernize_annotations: true
+            filters:
+              - "!^_"
 
 theme:
   logo: images/navlogo.png
+  favicon: images/navlogo.png
   name: material
   custom_dir: docs/overrides
   features:
@@ -86,6 +94,8 @@ theme:
     - content.action.edit
     - header.autohide
     - announce.dismiss
+    - navigation.footer
+    - navigation.indexes
   palette:
     # Palette toggle for automatic mode
     - media: "(prefers-color-scheme)"
@@ -111,14 +121,27 @@ theme:
         icon: material/brightness-4
         name: Switch to automatic mode
 
+copyright: >-
+  Copyright &copy; Brown University —
+  <a href="https://lnccbrown.github.io/HSSM/">HSSM</a> ·
+  <a href="https://lnccbrown.github.io/ssm-simulators/">ssm-simulators</a> ·
+  <a href="https://lnccbrown.github.io/LANfactory/">LANfactory</a>
+
 extra:
   homepage: "https://lnccbrown.github.io/LANfactory/"
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/lnccbrown/LANfactory
+    - icon: material/forum
+      link: https://github.com/lnccbrown/HSSM/discussions
 
 extra_css:
   - "styles/extra.css"
 
 markdown_extensions:
   - admonition
+  - toc:
+      permalink: true
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span


### PR DESCRIPTION
Phase 1 of the docs overhaul: adopt the shared ecosystem brand bundle from lnccbrown/HSSMSpine#42 (`docs-brand/`), the single source of truth for the visual identity of the HSSM / ssm-simulators / LANfactory doc sites.

## What changes

- **Broken responsive banner fixed** — the announcement banner's markup referenced helper classes (`show-on-small`, `right-margin`, `move-down`) that this site's `extra.css` never defined; the vendored bundle CSS supplies them, and aligns typography with HSSM.
- **Hardcoded version banner replaced** — the `v0.8.0 is out!` banner (stale on every release) becomes the shared repo-agnostic, version-free template; the release link derives from `config.repo_url`.
- **Favicon added** — shared nav logo, replacing the Material default.
- **Ecosystem footer strip** — the `copyright:` line now links the three sibling doc sites from every page.
- **Prev/next links** — `navigation.footer` (+ `navigation.indexes`) for learning-path wayfinding; social icons route questions to HSSM Discussions, the ecosystem's one forum.
- **API rendering unified** — mkdocstrings options replaced with HSSM's modern block (deprecated `import:` → `inventories:`, numpy docstrings, `filters: ["!^_"]`, summary tables) so API pages render identically across the ecosystem sites. `api/config.md` gains an explicit `network_configs` directive to keep that module documented now that `show_submodules` is gone.

## Verification

- `uv run mkdocs build --strict`: exit 0, **0 warnings** (locally, with the `docs` dependency group from #114).
- Built site spot-checked: favicon link, version-free banner, footer strip, two social icons, and all five API pages rendering their public members.

Bundle files (`extra.css`, `main.html`, `navlogo.png`) are byte-for-byte copies of the canonical bundle; `navlogo.png` was already identical. No notebooks or page content touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented the available network configuration options.
  - Improved API reference presentation and heading permalink support.
  - Added clearer site navigation, footer details, social links, and favicon branding.
  - Refreshed typography, layout, notebook output sizing, landing-page styling, and responsive behavior.
  - Updated the release announcement to link dynamically to the latest release.
  - Revised the support prompt to direct questions to GitHub Discussions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->