### PR TITLE
docs: Diátaxis nav restructure + What LANs are explanation page

### DIFF
--- a/docs/basic_tutorial/basic_tutorial_lan_jax.ipynb
+++ b/docs/basic_tutorial/basic_tutorial_lan_jax.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# How to train with the JAX backend"
+    "# Train with the JAX backend"
    ]
   },
   {

--- a/docs/basic_tutorial/basic_tutorial_lan_torch.ipynb
+++ b/docs/basic_tutorial/basic_tutorial_lan_torch.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Train a network (PyTorch LAN)"
+    "# Train your first LAN (PyTorch)"
    ]
   },
   {

--- a/docs/exporting_bayesflow_models.md
+++ b/docs/exporting_bayesflow_models.md
@@ -1,4 +1,4 @@
-# Exporting bayesflow-trained networks to ONNX
+# bayesflow export: architectures and constraints
 
 > The artifact rules every exporter here satisfies are collected in
 > [The ONNX likelihood contract](https://lnccbrown.github.io/HSSM/how_to/custom_onnx_likelihoods/).

--- a/docs/exporting_sbi_models.md
+++ b/docs/exporting_sbi_models.md
@@ -1,4 +1,4 @@
-# Exporting sbi-trained networks to ONNX
+# sbi export: architectures and constraints
 
 LANfactory's [`transform_sbi_to_onnx`](api/onnx.md) wraps a trained
 [`sbi`](https://github.com/sbi-dev/sbi) estimator and writes a single-trial

--- a/docs/tutorials/exporting_bayesflow_to_onnx.ipynb
+++ b/docs/tutorials/exporting_bayesflow_to_onnx.ipynb
@@ -19,7 +19,7 @@
     }
    },
    "source": [
-    "# Exporting a `bayesflow` model to ONNX for HSSM\n",
+    "# Export a bayesflow model to ONNX\n",
     "\n",
     "[`bayesflow`](https://github.com/bayesflow-org/bayesflow) trains amortized\n",
     "neural likelihood (`ContinuousApproximator`) and ratio (`RatioApproximator`)\n",

--- a/docs/tutorials/exporting_sbi_to_onnx.ipynb
+++ b/docs/tutorials/exporting_sbi_to_onnx.ipynb
@@ -19,7 +19,7 @@
     }
    },
    "source": [
-    "# Exporting an `sbi` model to ONNX for HSSM\n",
+    "# Export an sbi model to ONNX\n",
     "\n",
     "[`sbi`](https://github.com/sbi-dev/sbi) trains neural likelihood (NLE) and\n",
     "ratio (NRE) estimators. HSSM can use them as differentiable likelihoods —\n",

--- a/docs/using_huggingface.md
+++ b/docs/using_huggingface.md
@@ -1,4 +1,4 @@
-# Using HuggingFace Hub
+# Share trained networks on HuggingFace Hub
 
 LANfactory provides CLI commands for uploading trained models to and downloading models from HuggingFace Hub.
 

--- a/docs/using_mlflow.md
+++ b/docs/using_mlflow.md
@@ -1,4 +1,4 @@
-# MLflow Tutorial for LANfactory
+# Track training runs with MLflow
 
 Track and manage your network training experiments with MLflow.
 

--- a/docs/what_are_lans.md
+++ b/docs/what_are_lans.md
@@ -20,14 +20,20 @@ That has two consequences worth internalising:
 
 ## The three network types
 
-LANfactory trains three variants, which differ in what they learn rather than
-in architecture:
+LANfactory trains three variants, which differ in what they learn — and in what
+their raw output means — rather than in architecture:
 
-| | Learns | Used for |
-|---|---|---|
-| **LAN** | log-likelihood of `(rt, choice)` | RT + choice inference |
-| **CPN** | choice probability | choice-only models |
-| **OPN** | probability of responding before a deadline | deadline / omission models |
+| | Learns | Training output | Loss | Used for |
+|---|---|---|---|---|
+| **LAN** | log-likelihood of `(rt, choice)` | `logprob` | Huber | RT + choice inference |
+| **CPN** | choice probability | `logits` | BCE-with-logits | choice-only models |
+| **OPN** | probability of responding before a deadline | `logits` | BCE-with-logits | deadline / omission models |
+
+The output column matters when you consume or validate an exported network:
+CPN and OPN heads emit **logits**, not probabilities. LANfactory's exporters
+apply the log-sigmoid transform at export time so the ONNX artifact emits log
+probabilities for every network type — but a network read straight from a
+training checkpoint has not had that applied.
 
 The [network types reference](network_types.md) carries the exact config
 deltas for each.

--- a/docs/what_are_lans.md
+++ b/docs/what_are_lans.md
@@ -1,0 +1,56 @@
+# What LANs are, and where LANfactory fits
+
+Many sequential sampling models (SSMs) have no closed-form likelihood. You can
+*simulate* from them cheaply, but you cannot write down the density that
+Bayesian inference needs. **Likelihood approximation networks** (LANs,
+[Fengler et al., 2021](https://elifesciences.org/articles/65074)) close that
+gap: a neural network is trained, once and offline, to approximate the
+log-likelihood of a trial given the model's parameters. Inference then calls
+the network instead of an analytical formula.
+
+That has two consequences worth internalising:
+
+- **Training is amortised.** The expensive step happens once per model, not
+  once per dataset. A trained network is an artifact you keep, share, and
+  reuse across studies.
+- **The network is only valid where it was trained.** Its parameter bounds are
+  the training bounds. Outside them the approximation is unconstrained, which
+  is why bounds travel with the artifact rather than being an inference-time
+  choice.
+
+## The three network types
+
+LANfactory trains three variants, which differ in what they learn rather than
+in architecture:
+
+| | Learns | Used for |
+|---|---|---|
+| **LAN** | log-likelihood of `(rt, choice)` | RT + choice inference |
+| **CPN** | choice probability | choice-only models |
+| **OPN** | probability of responding before a deadline | deadline / omission models |
+
+The [network types reference](network_types.md) carries the exact config
+deltas for each.
+
+## Where LANfactory sits
+
+LANfactory is the **training** layer of the HSSM ecosystem — it neither
+simulates nor performs inference:
+
+| Package | Owns |
+|---|---|
+| [ssm-simulators](https://lnccbrown.github.io/ssm-simulators/) | the generative models and the training data |
+| **LANfactory** | dataloaders, network factories, training loops, ONNX export |
+| [HSSM](https://lnccbrown.github.io/HSSM/) | Bayesian inference using the exported networks as likelihoods |
+
+The handoff between the last two is a file: an ONNX graph obeying
+[the ONNX likelihood contract](https://lnccbrown.github.io/HSSM/how_to/custom_onnx_likelihoods/).
+Because that contract is framework-agnostic, LANfactory also exports networks
+trained *elsewhere* — sbi and BayesFlow — into the same consumable form, which
+is what the two export guides cover.
+
+## Where to go next
+
+- [Train your first LAN (PyTorch)](basic_tutorial/basic_tutorial_lan_torch.ipynb) — the end-to-end walkthrough
+- [Network types: LAN, CPN, OPN](network_types.md) — config deltas for the variants
+- [Share trained networks on HuggingFace Hub](using_huggingface.md) — publishing the artifact

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,23 +7,26 @@ edit_uri: edit/main/docs
 nav:
   - Home:
       - Overview: index.md
-  - Tutorials:
-      - Train a network (PyTorch LAN): basic_tutorial/basic_tutorial_lan_torch.ipynb
-      - How to train with the JAX backend: basic_tutorial/basic_tutorial_lan_jax.ipynb
-      - Exporting sbi → ONNX: tutorials/exporting_sbi_to_onnx.ipynb
-      - Exporting bayesflow → ONNX: tutorials/exporting_bayesflow_to_onnx.ipynb
-  - Guides:
+  - Learn:
+      - Train your first LAN (PyTorch): basic_tutorial/basic_tutorial_lan_torch.ipynb
+  - How-to guides:
+      - Train with the JAX backend: basic_tutorial/basic_tutorial_lan_jax.ipynb
+      - Export an sbi model to ONNX: tutorials/exporting_sbi_to_onnx.ipynb
+      - Export a bayesflow model to ONNX: tutorials/exporting_bayesflow_to_onnx.ipynb
+      - Track training runs with MLflow: using_mlflow.md
+      - Share trained networks on HuggingFace Hub: using_huggingface.md
+  - Explanations:
+      - What LANs are, and where LANfactory fits: what_are_lans.md
+  - Reference:
       - "Network types: LAN, CPN, OPN": network_types.md
-      - MLflow Integration: using_mlflow.md
-      - HuggingFace Hub: using_huggingface.md
-      - Exporting sbi Models: exporting_sbi_models.md
-      - Exporting bayesflow Models: exporting_bayesflow_models.md
-  - API:
-      - config: api/config.md
-      - hf: api/hf.md
-      - onnx: api/onnx.md
-      - trainers: api/trainers.md
-      - utils: api/utils.md
+      - sbi export — architectures and constraints: exporting_sbi_models.md
+      - bayesflow export — architectures and constraints: exporting_bayesflow_models.md
+      - API:
+          - config: api/config.md
+          - hf: api/hf.md
+          - onnx: api/onnx.md
+          - trainers: api/trainers.md
+          - utils: api/utils.md
 
 validation:
   omitted_files: warn


### PR DESCRIPTION
Phase 3 of the ecosystem docs overhaul. All 15 existing nav entries preserved (+1 new page); no file moves, no redirects, no re-execution.

- **`Tutorials` was 1-for-4** (only the torch training notebook is a Diátaxis tutorial) and **`Guides` was "everything that isn't a notebook"** (2 how-to, 3 reference). Labels had already been half-migrated to task-first; the buckets never followed. Now: Learn (1) / How-to guides (5) / Explanations (1) / Reference (3 + API).
- **New `docs/what_are_lans.md`** — the repo had zero standalone explanation content: the "what a LAN is and why you'd want one" prose was copy-pasted into both training notebooks and paraphrased in `index.md`. The page states the amortisation tradeoff, why training bounds travel with the artifact, the LAN/CPN/OPN distinction, and where LANfactory sits between ssm-simulators and HSSM — linking the ONNX contract as the handoff.
- **Shared ecosystem section vocabulary** (Home / Learn / How-to guides / Explanations / Reference), with **API folded under Reference**, matching HSSM and ssm-simulators so the tab strip is positionally identical across the three sites.
- **Task-first titles** on 4 notebooks and 4 markdown pages ("MLflow Tutorial for LANfactory" → "Track training runs with MLflow"; the two export guides now name themselves as the architecture/constraint references they are). Notebook H1s retitled too, since mkdocs-jupyter uses them as sidebar titles.

`mkdocs build --strict` green; new sections verified in the built sidebar.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new guide explaining LANs, amortized training, supported network types, and the HSSM workflow.
  * Expanded documentation for exporting Bayesflow and SBI models to ONNX, including supported architectures and constraints.
  * Reorganized documentation navigation into Learn, How-to, Explanations, and Reference sections.
  * Clarified tutorial titles for JAX, PyTorch, ONNX export, HuggingFace Hub, and MLflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->