### PR TITLE
docs: point at the ecosystem hub instead of a partial map

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,8 +25,8 @@ exports the trained networks to ONNX so they can serve as likelihoods in
 ## Ecosystem fit
 
 LANfactory is the network-training layer of the HSSM ecosystem: it trains
-LAN/CPN/OPN networks on simulated data and exports them to ONNX, in the form
-HSSM consumes as likelihoods.
+LAN/CPN/OPN networks on simulated data and exports them to ONNX in the form
+that HSSM consumes as likelihoods.
 
 For the full map — what each package owns, how artifacts flow between them,
 and which versions work together — see

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,13 +24,13 @@ exports the trained networks to ONNX so they can serve as likelihoods in
 
 ## Ecosystem fit
 
-LANfactory is the network-training layer of the HSSM ecosystem:
+LANfactory is the network-training layer of the HSSM ecosystem: it trains
+LAN/CPN/OPN networks on simulated data and exports them to ONNX, in the form
+HSSM consumes as likelihoods.
 
-| Package | Role |
-| --- | --- |
-| [ssm-simulators](https://lnccbrown.github.io/ssm-simulators/) | Simulates SSMs and generates the training data LANfactory consumes. |
-| LANfactory (this package) | Trains LAN/CPN/OPN networks on that data; exports them to ONNX. |
-| [HSSM](https://lnccbrown.github.io/HSSM/) | Consumes the exported ONNX networks as likelihoods for Bayesian inference. |
+For the full map — what each package owns, how artifacts flow between them,
+and which versions work together — see
+[The HSSM ecosystem](https://lnccbrown.github.io/HSSM/ecosystem/).
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ edit_uri: edit/main/docs
 nav:
   - Home:
       - Overview: index.md
+      - The HSSM ecosystem: https://lnccbrown.github.io/HSSM/ecosystem/
   - Learn:
       - Train your first LAN (PyTorch): basic_tutorial/basic_tutorial_lan_torch.ipynb
   - How-to guides:


### PR DESCRIPTION
Phase 4 companion to lnccbrown/HSSMSpine#48 (the spine-authored ecosystem hub, published at https://lnccbrown.github.io/HSSM/ecosystem/).

- The landing page's "Ecosystem fit" table described the ecosystem from this package's vantage point and was incomplete — it omitted LAN_pipeline_minimal entirely and never mentioned the HuggingFace artifact hop. It now states this package's role in two sentences and links the complete map.
- `The HSSM ecosystem` added to the Home nav group, in the same position it occupies on the sibling sites.

`mkdocs build --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Ecosystem fit section with a concise description of LANfactory’s training and ONNX export responsibilities.
  * Added a link to the HSSM ecosystem overview.
  * Added “The HSSM ecosystem” to the documentation navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->