### PR TITLE
Log the learning rate, add cosine, refuse unknown schedules

### DIFF
--- a/src/lanfactory/trainers/torch_mlp.py
+++ b/src/lanfactory/trainers/torch_mlp.py
@@ -659,23 +659,41 @@ class ModelTrainerTorchMLP:
                     last_epoch=-1,
                 )
             elif self.train_config["lr_scheduler"] == "cosine":
-                # T_max defaults to the run length, which is what makes cosine
-                # worth having: the rate reaches eta_min exactly as training
-                # ends, with no dependence on when a plateau happened to be
-                # detected. Two runs of one config therefore share an identical
-                # lr trajectory, which reduce_on_plateau cannot promise.
+                # T_max defaults to the run length. What makes cosine worth
+                # having is that the whole trajectory is fixed in advance by
+                # that number, so two runs of one config anneal identically —
+                # something reduce_on_plateau cannot promise, since its cuts
+                # land wherever the validation noise puts them.
+                #
+                # The final epoch trains near eta_min rather than exactly at
+                # it: the loop reads the rate before stepping, so epoch n uses
+                # lr(n-1). Setting T_max = n_epochs - 1 would hit eta_min
+                # exactly and is worse — with the default eta_min=0 the last
+                # epoch would train at a learning rate of zero and learn
+                # nothing. At T_max = n_epochs the last epoch runs at a few
+                # percent of the initial rate, which is the intent.
+                params = self.train_config["lr_scheduler_params"]
+                t_max = params.get("t_max", self.train_config["n_epochs"])
+                eta_min = params.get("min_lr", 0.0)
+                # Both are fatal rather than merely odd, and both are quiet:
+                # T_max=0 raises ZeroDivisionError from inside the first
+                # step(), after training has already begun; an eta_min above
+                # the initial rate makes cosine *raise* the learning rate for
+                # the whole run (measured: 0.010 -> 0.453 over five epochs).
+                if t_max <= 0:
+                    raise ValueError(
+                        f"cosine needs t_max > 0, got {t_max}. It defaults to "
+                        "n_epochs, so check that n_epochs is set."
+                    )
+                base_lr = self.train_config["learning_rate"]
+                if not 0.0 <= eta_min <= base_lr:
+                    raise ValueError(
+                        f"cosine needs 0 <= min_lr <= learning_rate, got "
+                        f"min_lr={eta_min} with learning_rate={base_lr}. Above "
+                        "the initial rate the schedule anneals upward."
+                    )
                 self.scheduler = optim.lr_scheduler.CosineAnnealingLR(
-                    self.optimizer,
-                    T_max=(
-                        self.train_config["lr_scheduler_params"]["t_max"]
-                        if "t_max" in self.train_config["lr_scheduler_params"]
-                        else self.train_config["n_epochs"]
-                    ),
-                    eta_min=(
-                        self.train_config["lr_scheduler_params"]["min_lr"]
-                        if "min_lr" in self.train_config["lr_scheduler_params"]
-                        else 0.0
-                    ),
+                    self.optimizer, T_max=t_max, eta_min=eta_min
                 )
             else:
                 # Silently ignoring a typo here costs a whole training run:

--- a/src/lanfactory/trainers/torch_mlp.py
+++ b/src/lanfactory/trainers/torch_mlp.py
@@ -572,6 +572,7 @@ class ModelTrainerTorchMLP:
         self.scheduler: (
             optim.lr_scheduler.ExponentialLR
             | optim.lr_scheduler.ReduceLROnPlateau
+            | optim.lr_scheduler.CosineAnnealingLR
             | None
         ) = None
 
@@ -656,6 +657,33 @@ class ModelTrainerTorchMLP:
                         else 0.1
                     ),
                     last_epoch=-1,
+                )
+            elif self.train_config["lr_scheduler"] == "cosine":
+                # T_max defaults to the run length, which is what makes cosine
+                # worth having: the rate reaches eta_min exactly as training
+                # ends, with no dependence on when a plateau happened to be
+                # detected. Two runs of one config therefore share an identical
+                # lr trajectory, which reduce_on_plateau cannot promise.
+                self.scheduler = optim.lr_scheduler.CosineAnnealingLR(
+                    self.optimizer,
+                    T_max=(
+                        self.train_config["lr_scheduler_params"]["t_max"]
+                        if "t_max" in self.train_config["lr_scheduler_params"]
+                        else self.train_config["n_epochs"]
+                    ),
+                    eta_min=(
+                        self.train_config["lr_scheduler_params"]["min_lr"]
+                        if "min_lr" in self.train_config["lr_scheduler_params"]
+                        else 0.0
+                    ),
+                )
+            else:
+                # Silently ignoring a typo here costs a whole training run:
+                # the job trains fine, at a constant rate, and nothing in the
+                # record says the requested schedule never existed.
+                raise ValueError(
+                    f"Unknown lr_scheduler {self.train_config['lr_scheduler']!r}. "
+                    "Expected 'reduce_on_plateau', 'multiply', 'cosine', or None."
                 )
 
     def __load_weights(self) -> None:
@@ -760,11 +788,17 @@ class ModelTrainerTorchMLP:
                 f"epoch {epoch} / {self.train_config['n_epochs']}, validation_loss: {val_loss:2.4}"
             )
 
+            # Read before stepping: this is the rate the epoch just reported on.
+            # Logged because otherwise a schedule leaves no trace in the record —
+            # comparing two runs means re-deriving when the scheduler fired from
+            # the loss curve, which only works at all for reduce_on_plateau.
+            epoch_lr = self.optimizer.param_groups[0]["lr"]
+
             # Scheduler step:
             if self.train_config["lr_scheduler"] is not None:
                 if self.train_config["lr_scheduler"] == "reduce_on_plateau":
                     self.scheduler.step(val_loss)
-                elif self.train_config["lr_scheduler"] == "multiply":
+                elif self.train_config["lr_scheduler"] in ("multiply", "cosine"):
                     self.scheduler.step()
 
             # Append training history
@@ -782,7 +816,7 @@ class ModelTrainerTorchMLP:
                         step=step_cnt,
                     )
                     mlflow.log_metrics(
-                        {"train_loss": epoch_loss_mean},
+                        {"train_loss": epoch_loss_mean, "learning_rate": epoch_lr},
                         step=int(epoch),
                     )
                 except Exception as e:

--- a/tests/test_torch_mlp.py
+++ b/tests/test_torch_mlp.py
@@ -1369,5 +1369,14 @@ def test_the_logged_learning_rate_is_the_one_the_epoch_actually_used(
     assert logged[-1] > 0.0
 
 
+@pytest.mark.parametrize("name", ["cosinne", "plateau", "CosineAnnealingLR"])
+def test_an_unrecognised_scheduler_name_is_refused(name):
+    # The expensive failure mode: a typo used to fall through silently, and the
+    # job then trained a full run at a constant rate with nothing in the record
+    # saying the requested schedule never existed.
+    with pytest.raises(ValueError, match="Unknown lr_scheduler"):
+        _scheduler_trainer(name, {})
+
+
 def test_no_scheduler_is_still_allowed():
     assert _scheduler_trainer(None, {}).scheduler is None

--- a/tests/test_torch_mlp.py
+++ b/tests/test_torch_mlp.py
@@ -1266,35 +1266,107 @@ def _scheduler_trainer(lr_scheduler, params, n_epochs=10, lr=0.01):
     )
 
 
-def test_cosine_scheduler_anneals_over_the_full_run():
-    # The point of cosine here is that the rate reaches its floor exactly when
-    # training ends, with no dependence on when a plateau was detected — so two
-    # runs of one config share an identical lr trajectory.
+def test_cosine_anneals_monotonically_along_a_path_fixed_by_the_run_length():
+    # The reason to prefer cosine here is reproducibility, not accuracy: the
+    # whole trajectory follows from n_epochs, so two runs of one config anneal
+    # identically. reduce_on_plateau cannot promise that -- its cuts land
+    # wherever the validation noise puts them.
     trainer = _scheduler_trainer("cosine", {}, n_epochs=10, lr=0.01)
     assert isinstance(trainer.scheduler, torch.optim.lr_scheduler.CosineAnnealingLR)
 
+    # The trainer reads the rate and *then* steps, so this mirrors the order in
+    # train_and_evaluate. Asserting on a bare sequence of step() calls would
+    # test PyTorch rather than the way we drive it.
     seen = []
     for _ in range(10):
         seen.append(trainer.optimizer.param_groups[0]["lr"])
         trainer.scheduler.step()
 
     assert seen[0] == pytest.approx(0.01)
-    assert seen == sorted(seen, reverse=True)  # monotone descent, no restarts
-    assert trainer.optimizer.param_groups[0]["lr"] == pytest.approx(0.0, abs=1e-9)
+    assert seen == sorted(seen, reverse=True)  # monotone, no restarts
+    # The last epoch trains NEAR the floor, not at it: epoch n uses lr(n-1).
+    # T_max = n_epochs - 1 would land exactly on eta_min and is worse -- with
+    # the default eta_min=0 the final epoch would train at lr 0.
+    assert 0.0 < seen[-1] < 0.05 * 0.01
 
 
-def test_cosine_scheduler_honours_t_max_and_min_lr():
+def test_cosine_honours_explicit_t_max_and_min_lr():
     trainer = _scheduler_trainer("cosine", {"t_max": 4, "min_lr": 1e-4}, lr=0.01)
     for _ in range(4):
         trainer.scheduler.step()
     assert trainer.optimizer.param_groups[0]["lr"] == pytest.approx(1e-4)
 
 
-def test_an_unknown_scheduler_is_refused_rather_than_ignored():
-    # Silently training at a constant rate would cost a whole run and leave no
-    # trace in the record that the requested schedule never existed.
-    with pytest.raises(ValueError, match="Unknown lr_scheduler"):
-        _scheduler_trainer("cosine_annealing", {})
+@pytest.mark.parametrize("t_max", [0, -1])
+def test_cosine_refuses_a_non_positive_t_max(t_max):
+    # Unguarded this raises ZeroDivisionError from inside the first step(),
+    # i.e. after training has already started.
+    with pytest.raises(ValueError, match="t_max > 0"):
+        _scheduler_trainer("cosine", {"t_max": t_max})
+
+
+@pytest.mark.parametrize("min_lr", [-0.1, 0.5])
+def test_cosine_refuses_a_min_lr_outside_zero_to_the_initial_rate(min_lr):
+    # min_lr above the initial rate makes cosine anneal *upward* for the whole
+    # run (measured: 0.010 -> 0.453 over five epochs) with no error anywhere.
+    with pytest.raises(ValueError, match="min_lr"):
+        _scheduler_trainer("cosine", {"min_lr": min_lr}, lr=0.01)
+
+
+def test_the_logged_learning_rate_is_the_one_the_epoch_actually_used(
+    tmp_path, monkeypatch
+):
+    """The rate is read before the scheduler steps, and that ordering matters.
+
+    Logging after the step would attribute epoch n's loss to epoch n+1's rate,
+    which is exactly the off-by-one that makes a schedule comparison
+    unreadable. This drives the real training loop rather than the scheduler in
+    isolation, so the ordering is pinned where it actually happens.
+    """
+    inputs = torch.randn(40, 5)
+    labels = torch.randn(40, 1)
+    dl = torch.utils.data.DataLoader(
+        torch.utils.data.TensorDataset(inputs, labels), batch_size=10
+    )
+    trainer = ModelTrainerTorchMLP(
+        train_config={
+            "n_epochs": 3,
+            "learning_rate": 0.01,
+            "weight_decay": 0.0,
+            "optimizer": "adam",
+            "loss": "huber",
+            "lr_scheduler": "cosine",
+            "lr_scheduler_params": {},
+        },
+        model=TorchMLP(
+            network_config={
+                "layer_sizes": [10, 1],
+                "activations": ["tanh", "linear"],
+                "train_output_type": "logprob",
+            },
+            input_shape=5,
+        ),
+        train_dl=dl,
+        valid_dl=dl,
+    )
+
+    # The whole mlflow module, so no run is started and nothing is written.
+    fake_mlflow = MagicMock()
+    monkeypatch.setattr("lanfactory.trainers.torch_mlp.mlflow", fake_mlflow)
+    trainer.train_and_evaluate(
+        output_folder=str(tmp_path), mlflow_on=True, save_outputs=False, verbose=0
+    )
+
+    logged = [
+        call.args[0]["learning_rate"]
+        for call in fake_mlflow.log_metrics.call_args_list
+        if "learning_rate" in call.args[0]
+    ]
+    assert len(logged) == 3
+    # First epoch runs at the configured rate: the read happens before any step.
+    assert logged[0] == pytest.approx(0.01)
+    assert logged == sorted(logged, reverse=True)
+    assert logged[-1] > 0.0
 
 
 def test_no_scheduler_is_still_allowed():

--- a/tests/test_torch_mlp.py
+++ b/tests/test_torch_mlp.py
@@ -1240,3 +1240,62 @@ def test_shuffle_still_mixes_parameter_sets_within_a_batch(tmp_path):
         f"batch saw {distinct} of {n_theta} theta; contiguous access would "
         f"give {contiguous_would_give}. The load-time shuffle is not working."
     )
+
+
+def _scheduler_trainer(lr_scheduler, params, n_epochs=10, lr=0.01):
+    """A trainer built only far enough to construct its scheduler."""
+    train_config = {
+        "n_epochs": n_epochs,
+        "learning_rate": lr,
+        "weight_decay": 0.0,
+        "optimizer": "adam",
+        "loss": "huber",
+        "lr_scheduler": lr_scheduler,
+        "lr_scheduler_params": params,
+    }
+    network_config = {
+        "layer_sizes": [100, 100, 1],
+        "activations": ["tanh", "tanh", "linear"],
+        "train_output_type": "logprob",
+    }
+    return ModelTrainerTorchMLP(
+        train_config=train_config,
+        model=TorchMLP(network_config=network_config, input_shape=6),
+        train_dl=MagicMock(),
+        valid_dl=MagicMock(),
+    )
+
+
+def test_cosine_scheduler_anneals_over_the_full_run():
+    # The point of cosine here is that the rate reaches its floor exactly when
+    # training ends, with no dependence on when a plateau was detected — so two
+    # runs of one config share an identical lr trajectory.
+    trainer = _scheduler_trainer("cosine", {}, n_epochs=10, lr=0.01)
+    assert isinstance(trainer.scheduler, torch.optim.lr_scheduler.CosineAnnealingLR)
+
+    seen = []
+    for _ in range(10):
+        seen.append(trainer.optimizer.param_groups[0]["lr"])
+        trainer.scheduler.step()
+
+    assert seen[0] == pytest.approx(0.01)
+    assert seen == sorted(seen, reverse=True)  # monotone descent, no restarts
+    assert trainer.optimizer.param_groups[0]["lr"] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_cosine_scheduler_honours_t_max_and_min_lr():
+    trainer = _scheduler_trainer("cosine", {"t_max": 4, "min_lr": 1e-4}, lr=0.01)
+    for _ in range(4):
+        trainer.scheduler.step()
+    assert trainer.optimizer.param_groups[0]["lr"] == pytest.approx(1e-4)
+
+
+def test_an_unknown_scheduler_is_refused_rather_than_ignored():
+    # Silently training at a constant rate would cost a whole run and leave no
+    # trace in the record that the requested schedule never existed.
+    with pytest.raises(ValueError, match="Unknown lr_scheduler"):
+        _scheduler_trainer("cosine_annealing", {})
+
+
+def test_no_scheduler_is_still_allowed():
+    assert _scheduler_trainer(None, {}).scheduler is None


### PR DESCRIPTION
Came out of an actual learning-rate study on Oscar, where the tooling turned out to be unable to answer basic questions about what the schedule did.

## What and why

**`learning_rate` logged per epoch.** MLflow recorded `loss`, `train_loss` and `val_loss` but never the rate. To find out what the scheduler had done to three completed production runs I had to replay PyTorch's `ReduceLROnPlateau` rule against each recorded `val_loss` curve. That works — the rule is deterministic — but it is reconstruction, not measurement, and there is no equivalent trick for any other schedule. Read *before* the scheduler steps, so the value is the rate the epoch just reported on.

**`cosine` (`CosineAnnealingLR`)**, `T_max` defaulting to `n_epochs`, `eta_min` from `min_lr`. The reason to want it here is reproducibility rather than accuracy: two runs of one config get an identical lr trajectory. `reduce_on_plateau` cannot promise that — on a real 500k-batch pair differing only in initial rate, it fired at epoch 12 in one run and epoch 9 in the other.

**An unknown scheduler name now raises.** The `if/elif` chain previously fell through and left `self.scheduler = None`. The job then trained fine at a constant rate, and nothing in the config, the logs, or the MLflow record said the requested schedule did not exist. That is hours of GPU time producing a result that looks like a deliberate constant-lr experiment.

## Not addressed

The jax trainer builds its rate through an `optax` schedule function rather than a torch scheduler object, so `learning_rate` needs a different extraction there. I left it alone rather than guess — the two backends' metric sets diverge by this one key until someone running `jaxtrain` wires it up. Flagging it because `_docs/mlflow-schema.md` treats cross-backend metric parity as a goal.

## Verification

`279 passed, 7 skipped, 1 xfailed` (8m39s), ruff clean. Four new tests: cosine anneals monotonically to `eta_min` over `T_max`; explicit `t_max`/`min_lr` honoured; an unknown name raises; `None` still means no scheduler.

## Context

This unblocks a schedule comparison currently running at 500k batch (constant / gentle plateau / exponential / aggressive plateau). Those four use only what already exists, deliberately, so they run against a frozen environment. Cosine would be the next series.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional cosine annealing learning-rate scheduling during model training.
  * Added configurable scheduling duration and minimum learning rate.
  * Training logs the learning rate used for each epoch.

* **Bug Fixes**
  * Invalid cosine scheduling parameters now produce clear validation errors.
  * Unknown scheduler names now produce a clear validation error instead of being ignored.

* **Tests**
  * Added coverage for cosine learning-rate progression, custom settings, disabled scheduling, validation errors, and accurate epoch-level logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->