### PR TITLE
docs: adopt the shared documentation platform

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,95 +3,37 @@ name: Docs
 on:
   pull_request:
     paths:
+      - ".github/workflows/docs.yml"
+      - ".lychee.toml"
       - "docs/**"
       - "mkdocs.yml"
+      - "notebooks/*.py"
       - "pyproject.toml"
-      - "lanfactory/**"
+      - "scripts/docs.sh"
+      - "src/lanfactory/**"
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
+      - ".github/workflows/docs.yml"
+      - ".lychee.toml"
       - "docs/**"
       - "mkdocs.yml"
+      - "notebooks/*.py"
       - "pyproject.toml"
-      - "lanfactory/**"
-  release:
-    types:
-      - published
+      - "scripts/docs.sh"
+      - "src/lanfactory/**"
   schedule:
-    # Weekly link check, Monday 06:17 UTC (off-peak).
+    # Retain the established Monday 06:17 UTC rendered-link check.
     - cron: "17 6 * * 1"
   workflow_dispatch:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 jobs:
-  build:
-    # Strict build: any mkdocs warning (broken nav entry, bad link, autorefs
-    # duplicate, deprecated option) fails the job.
-    if: github.event_name != 'schedule'
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: "latest"
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
-
-      - name: Install docs dependencies
-        run: uv sync --group docs
-
-      - name: Build docs (strict)
-        run: uv run mkdocs build --strict
-
-  deploy:
-    # Deploy the live site on release, on docs changes landing in main, or on
-    # manual dispatch — never for PRs.
-    if: >-
-      github.event_name == 'release' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'workflow_dispatch'
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: "latest"
-          enable-cache: true
-          cache-dependency-glob: "pyproject.toml"
-
-      - name: Install docs dependencies
-        run: uv sync --group docs
-
-      - name: Deploy docs to GitHub Pages
-        run: uv run mkdocs gh-deploy --force
-
-  linkcheck:
-    # External links rot independently of code changes, so this runs on a
-    # weekly schedule (plus manual dispatch) rather than on every PR.
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Check links
-        uses: lycheeverse/lychee-action@v2
-        with:
-          args: --no-progress "docs/**/*.md" "README.md"
-          fail: true
+  docs:
+    uses: lnccbrown/HSSMSpine/.github/workflows/reusable-docs.yml@1c8129bb4c0997ada5b4d062e05357757c86eb90
+    with:
+      system-profile: none

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - ".github/workflows/docs.yml"
+      - ".github/workflows/reusable-docs.yml"
       - ".lychee.toml"
       - "docs/**"
       - "mkdocs.yml"
@@ -15,6 +16,7 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/docs.yml"
+      - ".github/workflows/reusable-docs.yml"
       - ".lychee.toml"
       - "docs/**"
       - "mkdocs.yml"
@@ -34,6 +36,6 @@ permissions:
 
 jobs:
   docs:
-    uses: lnccbrown/HSSMSpine/.github/workflows/reusable-docs.yml@1c8129bb4c0997ada5b4d062e05357757c86eb90
+    uses: ./.github/workflows/reusable-docs.yml
     with:
       system-profile: none

--- a/.github/workflows/reusable-docs.yml
+++ b/.github/workflows/reusable-docs.yml
@@ -1,0 +1,142 @@
+name: Reusable native docs
+
+on:
+  workflow_call:
+    inputs:
+      system-profile:
+        description: Linux system dependencies (none, blas-lapack, or gsl)
+        required: false
+        default: none
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Validate system profile
+        shell: bash
+        env:
+          SYSTEM_PROFILE: ${{ inputs['system-profile'] }}
+        run: |
+          case "$SYSTEM_PROFILE" in
+            none|blas-lapack|gsl) ;;
+            *)
+              echo "Unsupported system-profile: $SYSTEM_PROFILE" >&2
+              exit 2
+              ;;
+          esac
+
+      - name: Check out caller repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.12.2"
+          enable-cache: true
+
+      - name: Install system dependencies
+        shell: bash
+        env:
+          SYSTEM_PROFILE: ${{ inputs['system-profile'] }}
+        run: |
+          case "$SYSTEM_PROFILE" in
+            none)
+              exit 0
+              ;;
+            blas-lapack)
+              packages=(libblas-dev liblapack-dev)
+              ;;
+            gsl)
+              packages=(libgsl-dev)
+              ;;
+          esac
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends "${packages[@]}"
+
+      - name: Build documentation
+        run: ./scripts/docs.sh build
+
+      - name: Verify Pages output
+        run: test -f site/index.html
+
+      # GitHub project sites are served below /<repository>/. Mount site/ at
+      # that path so Lychee can resolve Material's root-relative URLs against
+      # the current artifact instead of requiring an already-deployed site.
+      - name: Mount rendered site at Pages path
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          if [[ ! "$GITHUB_REPOSITORY" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+            echo "Unsupported repository name: $GITHUB_REPOSITORY" >&2
+            exit 2
+          fi
+          docs_project="${GITHUB_REPOSITORY#*/}"
+          if [[ "$docs_project" == "." || "$docs_project" == ".." ]]; then
+            echo "Unsupported Pages project path: $docs_project" >&2
+            exit 2
+          fi
+          docs_link_root="$RUNNER_TEMP/docs-link-root"
+          mkdir -p -- "$docs_link_root"
+          ln -s -- "$GITHUB_WORKSPACE/site" "$docs_link_root/$docs_project"
+
+      # Link-check rendered HTML so generated reference and notebook links are
+      # covered. Schedules and manual dispatches remain in the caller workflow.
+      - name: Check rendered links
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: >-
+            --config '${{ github.workspace }}/.lychee.toml'
+            --root-dir '${{ runner.temp }}/docs-link-root'
+            --no-progress
+            '${{ github.workspace }}/site/**/*.html'
+          fail: true
+          failIfEmpty: true
+
+      - name: Upload Pages artifact
+        if: >-
+          github.ref == 'refs/heads/main' &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: site
+
+  deploy:
+    name: Deploy documentation
+    needs: build
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: docs-pages-${{ github.repository }}
+      cancel-in-progress: false
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Deploy Pages artifact
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,4 @@
+cache = true
+max_cache_age = "1d"
+max_retries = 3
+timeout = 30

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ notebooks/                     # Test notebooks
 ## Build & Tooling
 
 - **Build system:** setuptools (pure Python, no compiled extensions)
-- **Package manager:** uv (with `uv.lock`)
+- **Package manager:** uv (`uv.lock` is intentionally ignored in this repository)
 - **Python:** >=3.12, <3.15 (classifiers target 3.12, 3.13, 3.14)
 - **Linting:** ruff (line length 88, via pre-commit)
 - **Type checking:** mypy
@@ -41,8 +41,8 @@ uv run pytest tests/
 uv run ruff check src/lanfactory && uv run ruff format --check .
 
 # Build docs
-uv run mkdocs build
-uv run mkdocs serve
+./scripts/docs.sh build
+./scripts/docs.sh serve
 
 # Train a network (PyTorch)
 uv run torchtrain --config-path <yaml> --training-data-folder <dir> --networks-path-base <dir>

--- a/README.md
+++ b/README.md
@@ -1,169 +1,61 @@
 <div style="position: relative; width: 100%;">
-  <img src="docs/images/mainlogo.png" style="width: 175px;">
+  <img src="docs/images/mainlogo.png" alt="LANfactory" style="width: 175px;">
   <a href="https://ccbs.carney.brown.edu/brainstorm" style="position: absolute; right: 0; top: 50%; transform: translateY(-50%);">
-    <img src="docs/images/Brain-Bolt-%2B-Circuits.gif" style="width: 100px;">
+    <img src="docs/images/Brain-Bolt-%2B-Circuits.gif" alt="Brown Brainstorm" style="width: 100px;">
   </a>
 </div>
 
-## LANfactory
+# LANfactory
 
 [![DOI](https://zenodo.org/badge/386076271.svg)](https://doi.org/10.5281/zenodo.17137303)
 ![PyPI](https://img.shields.io/pypi/v/lanfactory)
-![PyPI_dl](https://img.shields.io/pypi/dm/lanfactory)
-[![GitHub pull requests](https://img.shields.io/github/issues-pr/lnccbrown/LANfactory)](https://github.com/lnccbrown/LANfactory/pulls)
-![Python Version](https://img.shields.io/pypi/pyversions/lanfactory)
+![PyPI downloads](https://img.shields.io/pypi/dm/lanfactory)
 [![Run tests](https://github.com/lnccbrown/LANfactory/actions/workflows/run_tests.yml/badge.svg)](https://github.com/lnccbrown/LANfactory/actions/workflows/run_tests.yml)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![codecov](https://codecov.io/gh/lnccbrown/LANfactory/branch/main/graph/badge.svg)](https://codecov.io/gh/lnccbrown/LANfactory)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+LANfactory trains likelihood approximation networks (LANs), choice probability
+networks (CPNs), and option probability networks (OPNs) with PyTorch or
+JAX/Flax. It exports concrete-shape ONNX artifacts for use as likelihoods in
+[HSSM](https://lnccbrown.github.io/HSSM/).
 
-Lightweight python package to help with training [LANs](https://elifesciences.org/articles/65074) (Likelihood approximation networks).
+[Documentation](https://lnccbrown.github.io/LANfactory/) ·
+[Start with the PyTorch tutorial](https://lnccbrown.github.io/LANfactory/basic_tutorial/basic_tutorial_lan_torch/) ·
+[API reference](https://lnccbrown.github.io/LANfactory/api/trainers/) ·
+[HSSM ecosystem map](https://lnccbrown.github.io/HSSM/ecosystem/)
 
-LANfactory also ships an ONNX exporter for [`sbi`](https://github.com/sbi-dev/sbi)-trained
-neural likelihood (NLE) and neural ratio (NRE) estimators, producing files
-HSSM can consume via its `loglik_kind="approx_differentiable"` path. See the
-[Exporting sbi Models guide](docs/exporting_sbi_models.md).
+## Install
 
-Please find the original [documentation here](https://lnccbrown.github.io/LANfactory/).
-
-### Cite LANfactory
-
-Use this DOI to cite `lanfactory`: [https://doi.org/10.5281/zenodo.17137303](https://doi.org/10.5281/zenodo.17137303)
-
-### Quick Start
-
-The `LANfactory` package is a light-weight convenience package for training `likelihood approximation networks` (LANs) in torch (or jaxtrain), starting from supplied training data.
-
-[LANs](https://elifesciences.org/articles/65074), although more general in potential scope of applications, were conceived in the context of sequential sampling modeling
-to account for cognitive processes giving rise to *choice* and *reaction time* data in *n-alternative forced choice experiments* commonly encountered in the cognitive sciences.
-
-For a basic tutorial on how to use the `LANfactory` package, please refer to the [basic tutorial notebook](docs/basic_tutorial/basic_tutorial_lan_torch.ipynb).
-
-#### Install
-
-To install the `LANfactory` package type,
-
-`pip install lanfactory`
-
-Necessary dependency should be installed automatically in the process.
-
-### Basic Tutorial
-
-Check the basic tutorial [here](docs/basic_tutorial/basic_tutorial_lan_torch.ipynb).
-
-### Command Line Interface
-
-LANfactory includes a command line interface with the commands `jaxtrain` and `torchtrain`, which train neural networks using `jax` and `torch` as backends, respectively.
-
-**Examples**
 ```bash
-jaxtrain --config-path config.yaml --training-data-folder my_generated_data --network-id 0 --dl-workers 3 --networks-path-base my_trained_network
+pip install lanfactory
 ```
+
+Optional integrations are available through the `mlflow`, `hf`, `sbi`, and
+`bayesflow` extras, or together through `lanfactory[all]`. The documentation is
+the canonical source for training, export, configuration, and sharing guidance.
+
+## Contributor bootstrap
+
+Install the development environment and run the package gates:
+
 ```bash
-torchtrain --config-path config.yaml --training-data-folder my_generated_data --network-id 0 --dl-workers 3 --networks-path-base my_trained_network
+uv sync --all-groups
+uv run pytest tests/
+uv run ruff check src/lanfactory
+uv run ruff format --check .
 ```
 
-`jaxtrain` and `torchtrain` share these core arguments
-* `--config-path`: Path to the YAML config file (optional)
-* `--training-data-folder`: Path to folder with data to train the neural network on
-* `--networks-path-base`: Path to the output folder for trained neural network
-* `--network-id`: ID for the neural network to train (default: 0)
-* `--dl-workers`: Number of cores to use with the dataloader class (default: 1)
-* `--log-level`: Set the logging level (default: WARNING)
+Build or serve the documentation through the repository-owned entry point:
 
-You can also view the help to see further documentation.
-
-Below is a sample (default) configuration file you can use with `jaxtrain` or `torchtrain`.
-
-```yaml
-NETWORK_TYPE: "lan"
-CPU_BATCH_SIZE: 1000
-GPU_BATCH_SIZE: 50000
-GENERATOR_APPROACH: "lan"
-OPTIMIZER_: "adam"
-N_EPOCHS: 20
-MODEL: "ddm"
-SHUFFLE: True
-LAYER_SIZES: [[100, 100, 100, 1], [100, 100, 100, 100, 1], [100, 100, 100, 100, 100, 1],
-              [120, 120, 120, 1], [120, 120, 120, 120, 1], [120, 120, 120, 120, 120, 1]]
-ACTIVATIONS: [['tanh', 'tanh', 'tanh'],
-              ['tanh', 'tanh', 'tanh', 'tanh'],
-              ['tanh', 'tanh', 'tanh', 'tanh', 'tanh'],
-              ['tanh', 'tanh', 'tanh'],
-              ['tanh', 'tanh', 'tanh', 'tanh'],
-              ['tanh', 'tanh', 'tanh', 'tanh', 'tanh']] # specifies all but output layer activation (output layer activation is determined by)
-WEIGHT_DECAY: 0.0
-TRAIN_VAL_SPLIT: 0.5
-N_TRAINING_FILES: 10000 # can be list
-LABELS_LOWER_BOUND: np.log(1e-7)
-LEARNING_RATE: 0.001
-LR_SCHEDULER: 'reduce_on_plateau'
-LR_SCHEDULER_PARAMS:
-  factor: 0.1
-  patience: 2
-  threshold: 0.001
-  min_lr: 0.00000001
-  verbose: True
+```bash
+./scripts/docs.sh build
+./scripts/docs.sh serve
 ```
 
-Configuration file parameter details follow:
+Notebook execution remains a separate package test workflow; the documentation
+build renders the committed notebook outputs without executing them.
 
-| Option | Definition |
-| ------ | ---------- |
-| `NETWORK_TYPE` | The type of network you want to train. Other options include "cpn", "opn", "gonogo" and "cpn_bce" |
-| `CPU_BATCH_SIZE` | Number of samples to work through before updating internal model parameters, when CPU is being used |
-| `GPU_BATCH_SIZE` | Number of samples to work through before updating internal model parameters, when GPU is being used |
-| `GENERATOR_APPROACH` | Compatible training data generator to train the respective LAN |
-| `OPTIMIZER` | Optimization algorithm used to train the network |
-| `N_EPOCHS` | Number of passes through the entire training dataset |
-| `MODEL` | Type of model that was simulated |
-| `SHUFFLE` | Boolean that represents whether training data is shuffled before each epoch |
-| `LAYER_SIZES` | Number of neurons in each layer of the neural network. Contains multiple vectors of layer sizes to choose the best network after iterating through all networks |
-| `ACTIVATIONS` | Type of function that decides whether a neuron should be activated or not, depending on the weighted sum of the inputs it receives. Contains multiple options due to iteration through multiple networks |
-| `WEIGHT_DECAY` | Controls the amount of regularization to prevent overfitting, also known as L2 regularization |
-| `TRAIN_VAL_SPLIT` | Percentage of files used for training data vs. validation |
-| `N_TRAINING_FILES` | Max number of training files to use for training and validation |
-| `LABELS_LOWER_BOUND` | Minimum value for training labels to prevent extreme or undefined values |
-| `LEARNING_RATE` | A hyperparameter that controls how much the model weights are adjusted during training. A smaller learning rate means slower training but potentially more accurate results |
-| `LR_SCHEDULER` | The learning rate scheduler used to adapt the learning rate during training. `reduce_on_plateau` reduces the learning rate when the validation loss stops improving. |
-| `LR_SCHEDULER_PARAMS` | A dictionary specifying the parameters for the learning rate scheduler. It includes: `factor` (multiplier applied to reduce the LR), `patience` (number of epochs with no improvement before reducing LR), `threshold` (minimum change to qualify as improvement), `min_lr` (minimum LR allowed), and `verbose` (whether to print updates). |
+## Citation
 
-To make your own configuration file, you can copy the example above into a new `.yaml` file and modify it with your preferences.
-
-If you are using `uv`, you can also use the `uv run` command to run `jaxtrain` or `torchtrain` from the command line
-
-### TorchMLP to ONNX Converter
-
-Once you have trained your model, you can convert it to the ONNX format using the provided `transform-onnx` command.
-
-```sh
-$ transform-onnx --help
- Usage: transform-onnx [OPTIONS]
-
- Convert a TorchMLP model to ONNX format.
-
-
-╭─ Options ───────────────────────────────────────────────────────────────────────────────────╮
-│ *  --network-config-file        TEXT     Path to the network configuration file (pickle).   │
-│                                          [required]                                         │
-│ *  --state-dict-file            TEXT     Path to the state dictionary file. [required]      │
-│ *  --input-shape                INTEGER  Size of the input tensor for the model. [required] │
-│ *  --output-onnx-file           TEXT     Path to the output ONNX file. [required]           │
-│    --help                                Show this message and exit.                        │
-╰─────────────────────────────────────────────────────────────────────────────────────────────╯
-```
-
-#### Example
-
-```sh
-$ transform-onnx --network-config-file my_lca_no_bias_4_torch_network_config.pkl \
-                 --state-dict-file my_lca_no_bias_4_torch_state_dict.pt \
-                 --input-shape 11 \
-                 --output-onnx-file my_lca_no_bias_4_torch.onnx
-```
-The produced onnx file can be used directly with the [`HSSM`](https://github.com/lnccbrown/HSSM) package.
-
-We hope this package may be helpful in case you attempt to train [LANs](https://elifesciences.org/articles/65074) for your own research.
-
-#### END
+Use the archived LANfactory release DOI:
+[10.5281/zenodo.17137303](https://doi.org/10.5281/zenodo.17137303).

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,9 +1,7 @@
-{#- HSSM ecosystem shared announcement banner.
+{#- HSSM ecosystem shared Material override.
     VENDORED COPY — source of truth: https://github.com/lnccbrown/HSSMSpine
     (docs-brand/main.html). Edit there and re-sync; local edits will be
-    flagged as drift. Repo-agnostic: the release link derives from
-    config.repo_url; questions route to the ecosystem's shared forum
-    (HSSM Discussions) by design. -#}
+    flagged as drift. -#}
 {% extends "base.html" %}
 {% block announce %}
 <span class="show-on-small right-margin">
@@ -12,11 +10,13 @@
     </span>
     Navigate the site here!
 </span>
+{% if config.extra and config.extra.release_announcement %}
 <span class="right-margin">
     <a href="{{ config.repo_url | trim('/') }}/releases/latest">
         A new release is out — read the release notes
     </a>
 </span>
+{% endif %}
 <span>
     <span class="twemoji">
         {% include ".icons/material/head-question.svg" %}
@@ -26,4 +26,8 @@
         Open a discussion!
     </a>
 </span>
+{% endblock %}
+{% block footer %}
+{% include "partials/ecosystem-links.html" %}
+{{ super() }}
 {% endblock %}

--- a/docs/overrides/partials/ecosystem-links.html
+++ b/docs/overrides/partials/ecosystem-links.html
@@ -1,0 +1,13 @@
+{#- Shared navigation, intentionally separate from site-owned legal text. -#}
+<nav class="hssm-ecosystem-links" aria-label="HSSM ecosystem">
+  <div class="hssm-ecosystem-links__inner">
+    <strong>HSSM ecosystem</strong>
+    <a href="https://lnccbrown.github.io/HSSM/">HSSM</a>
+    <a href="https://lnccbrown.github.io/ssm-simulators/">ssm-simulators</a>
+    <a href="https://lnccbrown.github.io/LANfactory/">LANfactory</a>
+    <a href="https://lnccbrown.github.io/LAN_pipeline_minimal/">LAN pipeline</a>
+    <a href="https://lnccbrown.github.io/HSSMCortex/">HSSMCortex</a>
+    <a href="https://lnccbrown.github.io/HSSMSpine/">HSSMSpine</a>
+    <a href="https://lnccbrown.github.io/HSSM/ecosystem/">Ecosystem map</a>
+  </div>
+</nav>

--- a/docs/styles/extra.css
+++ b/docs/styles/extra.css
@@ -108,3 +108,29 @@ div .md-sidebar__inner nav .md-nav__list {
   width: 35px;
   height: 35px;
 }
+
+/* -- ecosystem navigation (legal text remains in MkDocs copyright) -- */
+.hssm-ecosystem-links {
+  background: var(--md-footer-bg-color);
+  color: var(--md-footer-fg-color);
+}
+
+.hssm-ecosystem-links__inner {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1rem;
+  align-items: baseline;
+  max-width: 61rem;
+  margin: 0 auto;
+  padding: 0.6rem 0.8rem;
+  font-size: 0.64rem;
+}
+
+.hssm-ecosystem-links__inner a {
+  color: var(--md-footer-fg-color--light);
+}
+
+.hssm-ecosystem-links__inner a:hover,
+.hssm-ecosystem-links__inner a:focus {
+  color: var(--md-accent-fg-color);
+}

--- a/docs/tutorials/exporting_bayesflow_to_onnx.ipynb
+++ b/docs/tutorials/exporting_bayesflow_to_onnx.ipynb
@@ -19,7 +19,7 @@
     }
    },
    "source": [
-    "# Export a bayesflow model to ONNX\n",
+    "# Exporting a `bayesflow` model to ONNX for HSSM\n",
     "\n",
     "[`bayesflow`](https://github.com/bayesflow-org/bayesflow) trains amortized\n",
     "neural likelihood (`ContinuousApproximator`) and ratio (`RatioApproximator`)\n",
@@ -30,10 +30,10 @@
     "hssm.HSSM(loglik=\"model.onnx\", loglik_kind=\"approx_differentiable\")\n",
     "```\n",
     "\n",
-    "This is the bayesflow sibling of the [sbi tutorial](exporting_sbi_to_onnx.ipynb):\n",
+    "This is the bayesflow sibling of the [sbi tutorial](../exporting_sbi_to_onnx/):\n",
     "same **train → export → verify** loop, with bayesflow's Keras-backed specifics.\n",
     "For the supported-architecture matrix and constraints, see the reference guide\n",
-    "[Exporting bayesflow Models](../exporting_bayesflow_models.md)."
+    "[Exporting bayesflow Models](../../exporting_bayesflow_models/)."
    ]
   },
   {
@@ -202,11 +202,8 @@
     "\n",
     "`transform_bayesflow_to_onnx` bakes the standardizer's accumulated mean/std\n",
     "into the graph as constants (sidestepping the dynamic-shape ops the live Keras\n",
-    "layer would emit) and writes a **rank-1** single-trial graph, opset 17. It satisfies the same\n",
-    "contract as the sbi and LAN exporters — **every input dim concrete, no dynamic\n",
-    "axes** ([canonical statement](https://lnccbrown.github.io/HSSM/how_to/custom_onnx_likelihoods/)) — though rank differs by tracer:\n",
-    "the LAN exporters emit rank-2 `(1, D)` Gemm graphs; rank-1 is required here\n",
-    "because the flow graph slices its input."
+    "layer would emit) and writes a **rank-1** single-trial graph, opset 17 — the\n",
+    "same contract as the sbi and LAN exporters, so HSSM consumes it identically."
    ]
   },
   {
@@ -309,7 +306,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='display: flex;flex: 1;flex-direction: row;justify-content: space-between;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span>**θ (parameters)**</span><marimo-ui-element object-id='Kclp-2' random-id='24d475e8-e5fe-0f77-a1e1-5ba86b295365'><marimo-slider data-initial-value='0.5' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003eθ[0]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element><marimo-ui-element object-id='Kclp-3' random-id='4a4cfa1e-2c6d-fe2d-b313-3358a535a766'><marimo-slider data-initial-value='-0.2' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003eθ[1]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element></div><div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span>**x (observation)**</span><marimo-ui-element object-id='Kclp-7' random-id='9accab62-e41e-7552-3dee-283754d51a0a'><marimo-slider data-initial-value='0.7' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003ex[0]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element><marimo-ui-element object-id='Kclp-8' random-id='b00b2b71-4ab9-e53e-343c-bba5ad699deb'><marimo-slider data-initial-value='0.3' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003ex[1]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element></div></div>"
+       "<div style='display: flex;flex: 1;flex-direction: row;justify-content: space-between;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span>**θ (parameters)**</span><marimo-ui-element object-id='Kclp-2' random-id='fc1ca620-6f2a-27c3-bc5d-8a5654c8f884'><marimo-slider data-initial-value='0.5' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003eθ[0]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element><marimo-ui-element object-id='Kclp-3' random-id='2929fa12-e553-79f0-a79f-53e47bebd358'><marimo-slider data-initial-value='-0.2' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003eθ[1]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element></div><div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span>**x (observation)**</span><marimo-ui-element object-id='Kclp-7' random-id='fe765398-f2dc-d053-7dbc-124296075f2b'><marimo-slider data-initial-value='0.7' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003ex[0]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element><marimo-ui-element object-id='Kclp-8' random-id='63571492-be15-bedf-9a70-3883686e3a17'><marimo-slider data-initial-value='0.3' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003ex[1]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element></div></div>"
       ]
      },
      "metadata": {},
@@ -397,8 +394,7 @@
    "source": [
     "## 4. Consume it in HSSM\n",
     "\n",
-    "The `.onnx` file drops into HSSM exactly like a LAN or sbi export\n",
-    "(full rules: [The ONNX likelihood contract](https://lnccbrown.github.io/HSSM/how_to/custom_onnx_likelihoods/)):\n",
+    "The `.onnx` file drops into HSSM exactly like a LAN or sbi export:\n",
     "\n",
     "```python\n",
     "import jax\n",
@@ -416,7 +412,7 @@
     "```\n",
     "\n",
     "For the consumption side end to end, see HSSM's\n",
-    "[Build HSSM models starting from ONNX files](https://lnccbrown.github.io/HSSM/tutorials/blackbox_contribution_onnx_example/)\n",
+    "[Build HSSM models starting from ONNX files](https://github.com/lnccbrown/HSSM/blob/main/docs/tutorials/blackbox_contribution_onnx_example.ipynb)\n",
     "tutorial. The **NRE** path is analogous: train a `RatioApproximator` and pass\n",
     "`mode=\"nre\"` to `transform_bayesflow_to_onnx`."
    ]
@@ -439,7 +435,7 @@
     "width": "medium"
    },
    "header": "# marimo source for the \"Exporting a bayesflow model to ONNX for HSSM\" tutorial.\n#\n# Regenerate the rendered docs notebook (with outputs) after editing:\n#   uv run marimo export ipynb notebooks/exporting_bayesflow_to_onnx.py \\\n#     -o docs/tutorials/exporting_bayesflow_to_onnx.ipynb --include-outputs\n#\n# Edit interactively with:  uv run marimo edit notebooks/exporting_bayesflow_to_onnx.py\n\n",
-   "marimo_version": "0.23.10"
+   "marimo_version": "0.24.0"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/exporting_sbi_to_onnx.ipynb
+++ b/docs/tutorials/exporting_sbi_to_onnx.ipynb
@@ -19,7 +19,7 @@
     }
    },
    "source": [
-    "# Export an sbi model to ONNX\n",
+    "# Exporting an `sbi` model to ONNX for HSSM\n",
     "\n",
     "[`sbi`](https://github.com/sbi-dev/sbi) trains neural likelihood (NLE) and\n",
     "ratio (NRE) estimators. HSSM can use them as differentiable likelihoods —\n",
@@ -34,7 +34,7 @@
     "This notebook runs the full **train → export → verify** loop end to end on\n",
     "a tiny toy, then points you at HSSM for the consumption side. For the\n",
     "supported-architecture matrix and constraints, see the reference guide\n",
-    "[Exporting sbi Models](../exporting_sbi_models.md)."
+    "[Exporting sbi Models](../../exporting_sbi_models/)."
    ]
   },
   {
@@ -390,6 +390,23 @@
        "  font-size: 0.75rem;\n",
        "  color: var(--slate-11);\n",
        "}\n",
+       "/* The cell output area is a scroll container, which clips the\n",
+       "   absolutely-positioned legend when it rises past the container's top\n",
+       "   edge. Where CSS anchor positioning is available, pin the legend to\n",
+       "   the info icon with fixed positioning instead: fixed elements escape\n",
+       "   scroll-container clipping, and the top layer is not needed. */\n",
+       "@supports (anchor-name: --nn-t-info) {\n",
+       "  .nn-t-info svg {\n",
+       "    anchor-name: --nn-t-info;\n",
+       "  }\n",
+       "  .nn-t-legend {\n",
+       "    position: fixed;\n",
+       "    position-anchor: --nn-t-info;\n",
+       "    bottom: calc(anchor(top) + 6px);\n",
+       "    right: anchor(right);\n",
+       "    position-try-fallbacks: flip-block;\n",
+       "  }\n",
+       "}\n",
        ".nn-t-legend-title {\n",
        "  font-size: 0.6875rem;\n",
        "  text-transform: uppercase;\n",
@@ -512,10 +529,8 @@
     "## 2. Export to ONNX\n",
     "\n",
     "`transform_sbi_to_onnx` wraps the trained estimator into a **rank-1**\n",
-    "single-trial graph (parameters first, observations second; opset 17). The graph is\n",
-    "rank-1 because flow/ratio graphs *slice* their input — a `(1, D)` trace bakes\n",
-    "`Slice` axes that fail under HSSM's `vmap`. The contract invariant itself is\n",
-    "**concrete dims, no dynamic axes** ([canonical statement](https://lnccbrown.github.io/HSSM/how_to/custom_onnx_likelihoods/))."
+    "single-trial graph (parameters first, observations second; opset 17). The\n",
+    "rank-1 contract is what lets HSSM `vmap` the graph over trials."
    ]
   },
   {
@@ -601,7 +616,7 @@
     {
      "data": {
       "text/html": [
-       "<div style='display: flex;flex: 1;flex-direction: row;justify-content: space-between;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span>**θ (parameters)**</span><marimo-ui-element object-id='Kclp-2' random-id='fd778053-9c66-a196-ba8d-07298b2dd8dc'><marimo-slider data-initial-value='0.5' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003eθ[0]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element><marimo-ui-element object-id='Kclp-3' random-id='1d84e961-50a3-b7cb-8e2d-08494150fbe8'><marimo-slider data-initial-value='-0.2' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003eθ[1]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element></div><div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span>**x (observation)**</span><marimo-ui-element object-id='Kclp-7' random-id='04db86fb-85bb-abe4-2982-ae021ef3e461'><marimo-slider data-initial-value='0.7' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003ex[0]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element><marimo-ui-element object-id='Kclp-8' random-id='c33c9eaf-2b30-26b7-32e1-80cb25595bc1'><marimo-slider data-initial-value='0.3' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003ex[1]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element></div></div>"
+       "<div style='display: flex;flex: 1;flex-direction: row;justify-content: space-between;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span>**θ (parameters)**</span><marimo-ui-element object-id='Kclp-2' random-id='59842d4e-ef99-8a03-d464-606635f48aac'><marimo-slider data-initial-value='0.5' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003eθ[0]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element><marimo-ui-element object-id='Kclp-3' random-id='557c63f4-7bf9-4164-c5fa-226d2532aa8e'><marimo-slider data-initial-value='-0.2' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003eθ[1]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element></div><div style='display: flex;flex: 1;flex-direction: column;justify-content: flex-start;align-items: normal;flex-wrap: nowrap;gap: 0.5rem'><span>**x (observation)**</span><marimo-ui-element object-id='Kclp-7' random-id='e07c5a6d-6db2-3fd1-3e1e-77b2017422cc'><marimo-slider data-initial-value='0.7' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003ex[0]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element><marimo-ui-element object-id='Kclp-8' random-id='9df14b38-570f-4537-d983-f7614c8fc0db'><marimo-slider data-initial-value='0.3' data-label='&quot;&#92;u003cspan class=&#92;&quot;markdown prose dark:prose-invert contents&#92;&quot;&#92;u003e&#92;u003cspan class=&#92;&quot;paragraph&#92;&quot;&#92;u003ex[1]&#92;u003c/span&#92;u003e&#92;u003c/span&#92;u003e&quot;' data-start='-3.0' data-stop='3.0' data-step='0.1' data-steps='[]' data-debounce='false' data-disabled='false' data-orientation='&quot;horizontal&quot;' data-show-value='false' data-include-input='false' data-full-width='false'></marimo-slider></marimo-ui-element></div></div>"
       ]
      },
      "metadata": {},
@@ -701,8 +716,7 @@
     "## 4. Consume it in HSSM\n",
     "\n",
     "The `.onnx` file drops into HSSM exactly like a LAN export — HSSM handles\n",
-    "the `vmap` over trials and (recent versions) the x64 flag —\n",
-    "the full rules are in [The ONNX likelihood contract](https://lnccbrown.github.io/HSSM/how_to/custom_onnx_likelihoods/):\n",
+    "the `vmap` over trials and (recent versions) the x64 flag:\n",
     "\n",
     "```python\n",
     "import jax\n",
@@ -745,7 +759,7 @@
     "width": "medium"
    },
    "header": "# marimo source for the \"Exporting an sbi model to ONNX for HSSM\" tutorial.\n#\n# Regenerate the rendered docs notebook (with outputs) after editing:\n#   uv run marimo export ipynb notebooks/exporting_sbi_to_onnx.py \\\n#     -o docs/tutorials/exporting_sbi_to_onnx.ipynb --include-outputs\n#\n# Edit interactively with:  uv run marimo edit notebooks/exporting_sbi_to_onnx.py\n\n",
-   "marimo_version": "0.23.10"
+   "marimo_version": "0.24.0"
   }
  },
  "nbformat": 4,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_url: https://lnccbrown.github.io/LANfactory/
 repo_name: lnccbrown/LANfactory
 repo_url: https://github.com/lnccbrown/LANfactory
 edit_uri: edit/main/docs
+exclude_docs: overrides/
 
 nav:
   - Home:
@@ -124,14 +125,11 @@ theme:
         icon: material/brightness-4
         name: Switch to automatic mode
 
-copyright: >-
-  Copyright &copy; Brown University —
-  <a href="https://lnccbrown.github.io/HSSM/">HSSM</a> ·
-  <a href="https://lnccbrown.github.io/ssm-simulators/">ssm-simulators</a> ·
-  <a href="https://lnccbrown.github.io/LANfactory/">LANfactory</a>
+copyright: Copyright &copy; 2021 Alexander Fengler. MIT License.
 
 extra:
   homepage: "https://lnccbrown.github.io/LANfactory/"
+  release_announcement: true
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/lnccbrown/LANfactory

--- a/notebooks/exporting_bayesflow_to_onnx.py
+++ b/notebooks/exporting_bayesflow_to_onnx.py
@@ -33,10 +33,10 @@ def _(mo):
     hssm.HSSM(loglik="model.onnx", loglik_kind="approx_differentiable")
     ```
 
-    This is the bayesflow sibling of the [sbi tutorial](exporting_sbi_to_onnx.ipynb):
+    This is the bayesflow sibling of the [sbi tutorial](../exporting_sbi_to_onnx/):
     same **train → export → verify** loop, with bayesflow's Keras-backed specifics.
     For the supported-architecture matrix and constraints, see the reference guide
-    [Exporting bayesflow Models](../exporting_bayesflow_models.md).
+    [Exporting bayesflow Models](../../exporting_bayesflow_models/).
     """)
     return
 

--- a/notebooks/exporting_sbi_to_onnx.py
+++ b/notebooks/exporting_sbi_to_onnx.py
@@ -37,7 +37,7 @@ def _(mo):
     This notebook runs the full **train → export → verify** loop end to end on
     a tiny toy, then points you at HSSM for the consumption side. For the
     supported-architecture matrix and constraints, see the reference guide
-    [Exporting sbi Models](../exporting_sbi_models.md).
+    [Exporting sbi Models](../../exporting_sbi_models/).
     """)
     return
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = ["setuptools", "wheel"]
 
 [project.urls]
 "Homepage" = "https://github.com/lnccbrown/LANFactory"
+"Documentation" = "https://lnccbrown.github.io/LANfactory/"
 "Bug Tracker" = "https://github.com/lnccbrown/LANFactory/issues"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,16 +100,14 @@ dev = [
     "marimo>=0.23",
 ]
 docs = [
-    "mkdocs>=1.6",
-    "mkdocs-material>=9.5",
-    "mkdocstrings[python]>=0.26",
-    "mkdocs-jupyter>=0.25",
-    "mkdocs-autorefs>=1.2",
-    # <1.2.3: the 1.2.3 release (2026-03-28) adds a dependency on "properdocs",
-    # an MkDocs impostor fork that injects a deceptive migration banner into
-    # every build. 1.2.2 depends only on mkdocs. Bump deliberately, after
-    # verifying upstream has removed the properdocs dependency.
-    "mkdocs-redirects>=1.2,<1.2.3",
+    "mkdocs==1.6.1",
+    "mkdocs-material==9.7.7",
+    "mkdocstrings==1.0.6",
+    "mkdocstrings-python==2.0.5",
+    "mkdocs-jupyter==0.26.3",
+    "mkdocs-autorefs==1.4.4",
+    # 1.2.3 depends on ProperDocs, which injects an unrelated migration banner.
+    "mkdocs-redirects==1.2.2",
 ]
 
 [tool.setuptools.packages.find]

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+usage() {
+  echo "Usage: ./scripts/docs.sh {build|serve}" >&2
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 2
+fi
+
+case "$1" in
+  build | serve)
+    command="$1"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+uv sync \
+  --python 3.12 \
+  --no-dev \
+  --group docs
+
+case "$command" in
+  build)
+    uv run --python 3.12 --no-dev --group docs --no-sync mkdocs build --strict
+    ;;
+  serve)
+    uv run --python 3.12 --no-dev --group docs --no-sync mkdocs serve
+    ;;
+esac


### PR DESCRIPTION
## Summary

- standardize the Python 3.12 and uv documentation entry point with exact shared pins
- adopt the locally vendored Spine-authored Pages artifact workflow with narrow permissions and corrected src/lanfactory path filters
- make the documentation site canonical for durable guidance while keeping the README focused on identity and bootstrap
- repair rendered links in the canonical marimo tutorial sources and regenerate their documentation exports
- preserve the existing notebook execution workflow and the gh-pages branch as a rollback reference

## Verification

- bash -n scripts/docs.sh
- ./scripts/docs.sh build
- pytest tests/test_notebooks.py --run-notebooks --no-cov -v: 4 passed
- Ruff check and format check: passed
- actionlint 1.7.12: passed
- rendered-site Lychee 0.24.2 check: 1,832 links, zero errors
- reusable workflow and four brand assets match the current HSSMSpine sources byte-for-byte
- no uv.lock or generated site output is tracked

## Rollout

Pull requests and feature-branch manual runs can build and link-check but cannot deploy. Once this PR is approved and green, Pages will be switched from the preserved gh-pages source to GitHub Actions immediately before merge. We will then verify one automatic main deployment and one manual-main rendered-link deployment at the unchanged public URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Refreshed the README with clearer project overview, installation guidance, supported frameworks, documentation links, and contributor instructions.
  - Added HSSM ecosystem navigation links to the documentation footer.
  - Improved release announcement visibility and updated footer branding.
  - Updated ONNX export tutorials and links, including clearer export requirements and compatibility details.

- **Chores**
  - Improved documentation publishing reliability, scheduled link checking, and GitHub Pages deployment.
  - Added a simpler command for building or previewing documentation locally.
  - Updated documentation dependency configuration and link-check performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->