### PR TITLE
Align the documentation legal notice

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,7 +125,7 @@ theme:
         icon: material/brightness-4
         name: Switch to automatic mode
 
-copyright: Copyright &copy; 2021 Alexander Fengler. MIT License.
+copyright: Copyright © 2021 Alexander Fengler. MIT License.
 
 extra:
   homepage: "https://lnccbrown.github.io/LANfactory/"


### PR DESCRIPTION
## Summary

- make MkDocs' site-owned legal notice exactly match the HSSMSpine documentation manifest
- retain the existing browser-visible footer and separate shared ecosystem navigation

## Verification

- `./scripts/docs.sh build`
- `git diff --check`

This is a one-line documentation-contract correction with no package or runtime changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation copyright notice to display the © symbol directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->